### PR TITLE
Add sed replacement in message box

### DIFF
--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -106,6 +106,9 @@ const Action = styled.div`
     }
 `;
 
+// For sed replacement
+const SED_REGEX = new RegExp("^s/([^])+/([^])+$");
+
 // ! FIXME: add to app config and load from app config
 export const CAN_UPLOAD_AT_ONCE = 4;
 
@@ -198,37 +201,63 @@ export default observer(({ channel }: Props) => {
         stopTyping();
         setMessage();
         setReplies([]);
-        playSound("outbound");
-
         const nonce = ulid();
-        dispatch({
-            type: "QUEUE_ADD",
-            nonce,
-            channel: channel._id,
-            message: {
-                _id: nonce,
-                channel: channel._id,
-                author: client.user!._id,
 
-                content,
-                replies,
-            },
-        });
+        // sed style message editing.
+        // If the user types for example `s/abc/def`, the string "abc"
+        // will be replaced with "def" in their last sent message.
+        if (SED_REGEX.test(content)) {
+            renderer.messages.reverse();
+            const msg = renderer.messages.find(
+                (msg) => msg.author_id === client.user!._id,
+            );
+            renderer.messages.reverse();
 
-        defer(() => renderer.jumpToBottom(SMOOTH_SCROLL_ON_RECEIVE));
+            if (msg) {
+                const [_, toReplace, newText, flags] =
+                    content.split(/(?<!\\)\//);
+                const newContent = msg.content
+                    .toString()
+                    .replace(new RegExp(toReplace, flags), newText);
 
-        try {
-            await channel.sendMessage({
-                content,
-                nonce,
-                replies,
-            });
-        } catch (error) {
+                if (newContent != msg.content) {
+                    msg.edit({
+                        content: newContent.substr(0, 2000),
+                    }).catch(console.warn);
+                }
+            }
+        } else {
+            playSound("outbound");
+
             dispatch({
-                type: "QUEUE_FAIL",
-                error: takeError(error),
+                type: "QUEUE_ADD",
                 nonce,
+                channel: channel._id,
+                message: {
+                    _id: nonce,
+                    channel: channel._id,
+                    author: client.user!._id,
+
+                    content,
+                    replies,
+                },
             });
+
+            defer(() => renderer.jumpToBottom(SMOOTH_SCROLL_ON_RECEIVE));
+
+            try {
+                await channel.sendMessage({
+                    content,
+                    nonce,
+                    replies,
+                });
+            } catch (error) {
+                dispatch({
+                    type: "QUEUE_FAIL",
+                    error: takeError(error),
+                    nonce,
+                });
+            }
         }
     }
 

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -223,7 +223,13 @@ export default observer(({ channel }: Props) => {
                 if (newContent != msg.content) {
                     msg.edit({
                         content: newContent.substr(0, 2000),
-                    }).catch(console.warn);
+                    })
+                        .then(() =>
+                            defer(() =>
+                                renderer.jumpToBottom(SMOOTH_SCROLL_ON_RECEIVE),
+                            ),
+                        )
+                        .catch(console.warn);
                 }
             }
         } else {


### PR DESCRIPTION
For example, if a user types `s/abc/def` and their last message is `abcdefghij`, that message will be edited to `defdefghij`.
[Video link because GitHub doesn't let me upload the video directly and ffmpeg refuses to convert it](https://fuckthefren.ch/sc/1628804103-Peek%202021-08-12%2023-32.webm)