### PR TITLE
Add background for loading image attachments

### DIFF
--- a/src/components/common/messaging/attachments/Attachment.module.scss
+++ b/src/components/common/messaging/attachments/Attachment.module.scss
@@ -92,8 +92,10 @@
 
 .image {
     cursor: pointer;
-}
+    width: 100%;
+    height: 100%;
 
-.loading {
-    background: var(--background);
+    &.loading {
+        background: var(--background);
+    }
 }

--- a/src/components/common/messaging/attachments/Attachment.module.scss
+++ b/src/components/common/messaging/attachments/Attachment.module.scss
@@ -93,3 +93,7 @@
 .image {
     cursor: pointer;
 }
+
+.loading {
+    background: var(--background);
+}

--- a/src/components/common/messaging/attachments/Attachment.tsx
+++ b/src/components/common/messaging/attachments/Attachment.tsx
@@ -11,6 +11,7 @@ import AttachmentActions from "./AttachmentActions";
 import { SizedGrid } from "./Grid";
 import Spoiler from "./Spoiler";
 import TextFile from "./TextFile";
+import ImageFile from "./ImageFile";
 
 interface Props {
     attachment: AttachmentI;
@@ -21,11 +22,8 @@ const MAX_ATTACHMENT_WIDTH = 480;
 
 export default function Attachment({ attachment, hasContent }: Props) {
     const client = useContext(AppContext);
-    const { openScreen } = useIntermediate();
     const { filename, metadata } = attachment;
     const [spoiler, setSpoiler] = useState(filename.startsWith("SPOILER_"));
-    // only used in image attachments
-    const [loading, setLoading] = useState(true);
 
     const url = client.generateFileURL(
         attachment,
@@ -41,24 +39,9 @@ export default function Attachment({ attachment, hasContent }: Props) {
                     height={metadata.height}
                     className={classNames({
                         [styles.margin]: hasContent,
-                        [styles.loading]: loading,
                         spoiler,
                     })}>
-                    <img
-                        src={url}
-                        alt={filename}
-                        className={styles.image}
-                        loading="lazy"
-                        onClick={() =>
-                            openScreen({ id: "image_viewer", attachment })
-                        }
-                        onLoad={() =>
-                            setLoading(false)
-                        }
-                        onMouseDown={(ev) =>
-                            ev.button === 1 && window.open(url, "_blank")
-                        }
-                    />
+                    <ImageFile attachment={attachment} />
                     {spoiler && <Spoiler set={setSpoiler} />}
                 </SizedGrid>
             );

--- a/src/components/common/messaging/attachments/Attachment.tsx
+++ b/src/components/common/messaging/attachments/Attachment.tsx
@@ -24,6 +24,8 @@ export default function Attachment({ attachment, hasContent }: Props) {
     const { openScreen } = useIntermediate();
     const { filename, metadata } = attachment;
     const [spoiler, setSpoiler] = useState(filename.startsWith("SPOILER_"));
+    // only used in image attachments
+    const [loading, setLoading] = useState(true);
 
     const url = client.generateFileURL(
         attachment,
@@ -39,6 +41,7 @@ export default function Attachment({ attachment, hasContent }: Props) {
                     height={metadata.height}
                     className={classNames({
                         [styles.margin]: hasContent,
+                        [styles.loading]: loading,
                         spoiler,
                     })}>
                     <img
@@ -48,6 +51,9 @@ export default function Attachment({ attachment, hasContent }: Props) {
                         loading="lazy"
                         onClick={() =>
                             openScreen({ id: "image_viewer", attachment })
+                        }
+                        onLoad={() =>
+                            setLoading(false)
                         }
                         onMouseDown={(ev) =>
                             ev.button === 1 && window.open(url, "_blank")

--- a/src/components/common/messaging/attachments/ImageFile.tsx
+++ b/src/components/common/messaging/attachments/ImageFile.tsx
@@ -1,0 +1,49 @@
+import {Attachment} from "revolt-api/types/Autumn";
+
+import styles from "./Attachment.module.scss";
+import classNames from "classnames";
+import {useContext, useState} from "preact/hooks";
+
+import {useIntermediate} from "../../../../context/intermediate/Intermediate";
+import {AppContext} from "../../../../context/revoltjs/RevoltClient";
+
+enum ImageLoadingState
+{
+    Loading,
+    Loaded,
+    Error
+}
+
+interface Props {
+    attachment: Attachment;
+}
+
+export default function ImageFile({ attachment }: Props)
+{
+    const [loading, setLoading] = useState(ImageLoadingState.Loading);
+    const client = useContext(AppContext);
+    const { openScreen } = useIntermediate();
+    const url = client.generateFileURL(attachment)!;
+
+    return <img
+        src={url}
+        alt={attachment.filename}
+        loading="lazy"
+        className={classNames(styles.image, {
+            [styles.loading]: loading !== ImageLoadingState.Loaded
+        })}
+        onClick={() =>
+            openScreen({id: "image_viewer", attachment})
+        }
+        onMouseDown={(ev) =>
+            ev.button === 1 && window.open(url, "_blank")
+        }
+        onLoad={() =>
+            setLoading(ImageLoadingState.Loaded)
+        }
+        onError={() =>
+            setLoading(ImageLoadingState.Error)
+        }
+
+    />
+}


### PR DESCRIPTION
This PR adds a simple background to image attachments that have not been loaded.

As of writing, this PR feels hacky at best. I'm looking for some guidance, as well as permission to make image files its own component (just like how [text files have their own component](https://github.com/revoltchat/revite/blob/master/src/components/common/messaging/attachments/TextFile.tsx)).

Demonstration:

https://user-images.githubusercontent.com/39029839/129476409-496cfef5-9738-4c90-a7a2-28ef83102fe0.mp4
