### PR TITLE
Make typing indicator fill entire space

### DIFF
--- a/src/components/common/messaging/bars/TypingIndicator.tsx
+++ b/src/components/common/messaging/bars/TypingIndicator.tsx
@@ -23,7 +23,7 @@ const Base = styled.div`
         user-select: none;
         align-items: center;
         flex-direction: row;
-        width: calc(100% - 3px);
+        width: 100%;
         color: var(--secondary-foreground);
         background: var(--secondary-background);
     }


### PR DESCRIPTION
Fix for https://github.com/revoltchat/revite/issues/109