### PR TITLE
Bump message editor rows to 10

### DIFF
--- a/src/pages/channels/messaging/MessageEditor.tsx
+++ b/src/pages/channels/messaging/MessageEditor.tsx
@@ -96,7 +96,7 @@ export default function MessageEditor({ message, finish }: Props) {
             <AutoComplete detached {...autoCompleteProps} />
             <TextAreaAutoSize
                 forceFocus
-                maxRows={3}
+                maxRows={10}
                 value={content}
                 maxLength={2000}
                 padding="var(--message-box-padding)"


### PR DESCRIPTION
Editing message this way feels less crowded when editing large messages.