### PR TITLE
Add trusted domains in external link prompt

### DIFF
--- a/src/context/intermediate/modals/ExternalLinkPrompt.tsx
+++ b/src/context/intermediate/modals/ExternalLinkPrompt.tsx
@@ -43,10 +43,10 @@ export function ExternalLinkModal({ onClose, link }: Props) {
                         onClose();
                     },
                     plain: true,
-                    children: "Trust this domain",
+                    children: <Text id="app.special.modals.external_links.trust_domain" />,
                 }
             ]}>
-            <Text id={"app.special.modals.external_links.short"} /> <br />
+            <Text id="app.special.modals.external_links.short" /> <br />
             <a>{link}</a>
         </Modal>
     );

--- a/src/context/intermediate/modals/ExternalLinkPrompt.tsx
+++ b/src/context/intermediate/modals/ExternalLinkPrompt.tsx
@@ -1,6 +1,7 @@
 import { Text } from "preact-i18n";
 
 import Modal from "../../../components/ui/Modal";
+import { dispatch } from "../../../redux";
 
 interface Props {
     onClose: () => void;
@@ -29,6 +30,21 @@ export function ExternalLinkModal({ onClose, link }: Props) {
                     confirmation: false,
                     children: "Cancel",
                 },
+                {
+                    onClick: () => {
+                        try {
+                            const url = new URL(link);
+                            dispatch({
+                                type: "TRUSTED_LINKS_ADD_DOMAIN",
+                                domain: url.hostname
+                            });
+                        } catch(e) {}
+                        window.open(link, "_blank");
+                        onClose();
+                    },
+                    plain: true,
+                    children: "Trust this domain",
+                }
             ]}>
             <Text id={"app.special.modals.external_links.short"} /> <br />
             <a>{link}</a>

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -14,6 +14,7 @@ import { QueuedMessage } from "./reducers/queue";
 import { SectionToggle } from "./reducers/section_toggle";
 import { Settings } from "./reducers/settings";
 import { SyncOptions } from "./reducers/sync";
+import { TrustedLinks } from "./reducers/trusted_links";
 import { Unreads } from "./reducers/unreads";
 
 export type State = {
@@ -29,6 +30,7 @@ export type State = {
     lastOpened: LastOpened;
     notifications: Notifications;
     sectionToggle: SectionToggle;
+    trustedLinks: TrustedLinks;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,6 +61,7 @@ store.subscribe(() => {
         lastOpened,
         notifications,
         sectionToggle,
+        trustedLinks,
     } = store.getState() as State;
 
     localForage.setItem("state", {
@@ -74,6 +77,7 @@ store.subscribe(() => {
         lastOpened,
         notifications,
         sectionToggle,
+        trustedLinks,
     });
 });
 

--- a/src/redux/reducers/index.ts
+++ b/src/redux/reducers/index.ts
@@ -12,6 +12,7 @@ import { sectionToggle, SectionToggleAction } from "./section_toggle";
 import { config, ConfigAction } from "./server_config";
 import { settings, SettingsAction } from "./settings";
 import { sync, SyncAction } from "./sync";
+import { trustedLinks, TrustedLinksAction } from "./trusted_links";
 import { unreads, UnreadsAction } from "./unreads";
 
 export default combineReducers({
@@ -27,6 +28,7 @@ export default combineReducers({
     lastOpened,
     notifications,
     sectionToggle,
+    trustedLinks,
 });
 
 export type Action =
@@ -42,4 +44,5 @@ export type Action =
     | LastOpenedAction
     | NotificationsAction
     | SectionToggleAction
+    | TrustedLinksAction
     | { type: "__INIT"; state: State };

--- a/src/redux/reducers/trusted_links.ts
+++ b/src/redux/reducers/trusted_links.ts
@@ -1,0 +1,37 @@
+export interface TrustedLinks {
+    domains?: string[];
+}
+
+export type TrustedLinksAction =
+    | { type: undefined }
+    | {
+          type: "TRUSTED_LINKS_ADD_DOMAIN";
+          domain: string;
+      }
+    | {
+          type: "TRUSTED_LINKS_REMOVE_DOMAIN";
+          domain: string;
+      };
+
+export function trustedLinks(
+    state = {} as TrustedLinks,
+    action: TrustedLinksAction,
+): TrustedLinks {
+    switch (action.type) {
+        case "TRUSTED_LINKS_ADD_DOMAIN":
+            return {
+                ...state,
+                domains: [
+                    ...(state.domains ?? []).filter((v) => v !== action.domain),
+                    action.domain,
+                ],
+            };
+        case "TRUSTED_LINKS_REMOVE_DOMAIN":
+            return {
+                ...state,
+                domains: state.domains?.filter((v) => v !== action.domain),
+            };
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
Stores trusted domains in state after trusting.

![](https://get.snaz.in/72igwcb.png)

- [x] translation ([pr](https://gitlab.insrt.uk/revolt/translations/-/merge_requests/12))