### PR TITLE
Clean up invalid invite page.

### DIFF
--- a/src/pages/invite/Invite.tsx
+++ b/src/pages/invite/Invite.tsx
@@ -54,7 +54,29 @@ export default function Invite() {
             <div className={styles.preloader}>
                 <RequiresOnline>
                     {error ? (
-                        <Overline type="error" error={error} />
+                        <div
+                            className={styles.invite}
+                            style={{
+                                backgroundImage: `url('https://autumn.revolt.chat/banners/yMurJiXf45VJpbal0X2zQkm4vaXsXGaRtoPUIcvPcH')`,
+                                width: "100%",
+                                height: "100%",
+                            }}>
+                            <div className={styles.details}>
+                                <h1>Invalid invite!</h1>
+                                <h2>
+                                    The invite may not exist or you don't have
+                                    permission to join.
+                                </h2>
+                                <div style="cursor: pointer;">
+                                    <Button contrast>
+                                        <ArrowBack
+                                            size={32}
+                                            onClick={() => history.push("/")}
+                                        />
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
                     ) : (
                         <Preloader type="spinner" />
                     )}


### PR DESCRIPTION
- Make it look similar to a valid invite page.
- Add back button which brings you to the home screen.

Fixes #157 

Only issue is the `background-url` is copied from the Testers invite page and this doesn't use i18n translations.

![before](https://user-images.githubusercontent.com/20918009/131408626-47bfec2b-dc86-4b14-bbf1-8ad96a10f053.png)

![after](https://user-images.githubusercontent.com/20918009/131408637-f2ef301e-7781-4fc3-a613-5af65a479e18.png)