### PR TITLE
Show errors for invalid length/username taken

### DIFF
--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -70,6 +70,7 @@ function BotEditor({ bot }: { bot: Data }) {
 
 export const MyBots = observer(() => {
     const client = useClient();
+    const { openScreen } = useIntermediate();
     const [bots, setBots] = useState<Bot[] | undefined>(undefined);
 
     useEffect(() => {
@@ -101,6 +102,11 @@ export const MyBots = observer(() => {
                         client.bots
                             .create({ name })
                             .then(({ bot }) => setBots([...(bots ?? []), bot]))
+                            .catch(() => {
+                                if (name.length < 2) return openScreen({ id: "error", error: "Username must be at least 2 characters long" });
+                                else if (name.length > 32) return openScreen({ id: "error", error: "Username must be no longer than 32 characters" });
+                                openScreen({ id: "error", error: "Username already taken" });
+                            })
                     }>
                     create
                 </Button>


### PR DESCRIPTION
Modifies the bots pane in settings to show an error popup for length (if < 2, if > 32) and if the chosen username is taken. This imports the showScreen method (found in the FileUploader file). This pull depends on [a change to the revolt.js library](https://github.com/revoltchat/revolt.js/pull/6) I have already submitted (and linked), which catches and throws any errors from the bots.create method.