### PR TITLE
increase padding for profile preview

### DIFF
--- a/src/pages/settings/panes/Panes.module.scss
+++ b/src/pages/settings/panes/Panes.module.scss
@@ -91,6 +91,7 @@
         display: grid;
         place-items: center;
         grid-template-columns: minmax(auto, 100%);
+        padding-bottom: 30px;
 
         > div {
             width: 100%;


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/42586271/131703643-a386fb45-7880-423e-8c02-b2bbe2eb5f32.png)

After:
![image](https://user-images.githubusercontent.com/42586271/131704055-5e7d883e-995c-4ed3-98ec-0f2c343f746e.png)

(I'm not dead-set on 30px, but I think it gives enough space for the preview to not blend in with the lower text.)