### PR TITLE
Fix translation string in Create Bot popover

### DIFF
--- a/src/context/intermediate/popovers/CreateBot.tsx
+++ b/src/context/intermediate/popovers/CreateBot.tsx
@@ -72,7 +72,7 @@ export function CreateBotModal({ onClose, onCreate }: Props) {
                 />
                 {error && (
                     <Overline type="error" error={error}>
-                        <Text id="app.special.popovers.create_bot.error" />
+                        <Text id="app.special.popovers.create_bot.failed" />
                     </Overline>
                 )}
             </form>


### PR DESCRIPTION
`app.special.popovers.create_bot.error` -> `app.special.popovers.create_bot.failed`