### PR TITLE
add tooltip/help icon for bot id

### DIFF
--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -1,5 +1,5 @@
 import { Key, Clipboard, Globe, Plus } from "@styled-icons/boxicons-regular";
-import { LockAlt } from "@styled-icons/boxicons-solid";
+import { LockAlt, HelpCircle } from "@styled-icons/boxicons-solid";
 import type { AxiosError } from "axios";
 import { observer } from "mobx-react-lite";
 import { Bot } from "revolt-api/types/Bots";
@@ -175,6 +175,12 @@ function BotCard({ bot, onDelete, onUpdate }: Props) {
                             </div>
 
                             <div className={styles.userid}>
+                                <Tooltip
+                                    content={
+                                        <Text id="app.settings.pages.bots.unique_id" />
+                                    }>
+                                    <HelpCircle size={16} />
+                                </Tooltip>
                                 <Tooltip
                                     content={<Text id="app.special.copy" />}>
                                     <a


### PR DESCRIPTION
(relies on revoltchat/translations#4)
![image](https://user-images.githubusercontent.com/42586271/132109541-8bd4748b-0ea1-40ee-83dd-12f876dae0c1.png)
