### PR TITLE
Use preferred monospace font for Theme Overrides code section

### DIFF
--- a/src/pages/settings/panes/Panes.module.scss
+++ b/src/pages/settings/panes/Panes.module.scss
@@ -263,7 +263,7 @@
             min-width: 0;
             flex-grow: 1;
             padding: 8px;
-            font-family: var(--codeblock-font);
+            font-family: var(--monospace-font);
             border-radius: var(--border-radius);
             background: var(--secondary-background);
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -5,7 +5,6 @@
     --ligatures: none;
     --text-size: 14px;
     --font: "Open Sans";
-    --codeblock-font: "Fira Code";
     --sidebar-active: var(--secondary-background);
 
     /**


### PR DESCRIPTION
The `.code` section under Theme Overrides in the Appearance settings uses the `--codeblock-font` variable, set to `"Fira Code"` and doesn't update to match the user's preferred monospace font (`--monospace-font`), making it inconsistent with the rest of the webapp (this was the only place the variable was used).

This creates issues when the user does not have Fira Code installed on their system and chooses a different monospace font, as it falls back to the browser default font (usually a serif font). See the screenshot below.
![image](https://user-images.githubusercontent.com/25019123/132117694-53fa7ecc-71f5-4cbe-bd9a-7e9121e18302.png)

This PR removes the variable and uses `--monospace-font` to match the rest of the site.