### PR TITLE
Add padding to settings category titles to align the visually with icons

### DIFF
--- a/src/components/ui/Category.tsx
+++ b/src/components/ui/Category.tsx
@@ -9,7 +9,7 @@ const CategoryBase = styled.div<Pick<Props, "variant">>`
     text-transform: uppercase;
 
     margin-top: 4px;
-    padding: 6px 0;
+    padding: 6px 0 6px 8px;
     margin-bottom: 4px;
     white-space: nowrap;
 


### PR DESCRIPTION
This change aligns the category titles in settings visually with the icons, which looks a bit more pleasant IMO.

Before | After
--- | ---
![Screenshot 2021-09-06 at 20 26 55](https://user-images.githubusercontent.com/39763575/132252474-c3eab307-25d3-4427-8241-979fb86795ae.png) | ![Screenshot 2021-09-06 at 20 26 43](https://user-images.githubusercontent.com/39763575/132252462-88fb6b53-b4c4-4335-b731-0b8c4ea87d49.png)

Also works on mobile:

Before | After
--- | ---
![Screen Shot 2021-09-06 at 20 28 51](https://user-images.githubusercontent.com/39763575/132252600-fbea0b62-b0dd-40b9-aa7b-2acbfc639455.png) | ![Screen Shot 2021-09-06 at 20 29 14](https://user-images.githubusercontent.com/39763575/132252624-f896bb0a-9a14-404b-9b1e-59fb48b0b141.png)
