### PR TITLE
Set deleted reply IDs to 0

### DIFF
--- a/src/lib/renderer/simple/SimpleRenderer.ts
+++ b/src/lib/renderer/simple/SimpleRenderer.ts
@@ -102,10 +102,6 @@ export const SimpleRenderer: RendererRoutines = {
 
                 if (replyIndex > -1){
                     m.reply_ids[replyIndex] = "0";
-
-                    runInAction(() => {
-                        renderer.emitScroll({ type: "StayAtBottom" });
-                    });
                 }
             }
         });


### PR DESCRIPTION
This is an attempt to fix #71 - I'm new to this codebase, so please excuse anything here that might be ineffective.

When a message is deleted, all messages in the renderer are iterated, and reply IDs of messages posted after the deleted message will be checked for the ID of the deleted message.