### PR TITLE
Filter "alt" languages when selecting based on navigator

### DIFF
--- a/src/redux/reducers/locale.ts
+++ b/src/redux/reducers/locale.ts
@@ -1,4 +1,4 @@
-import { Language } from "../../context/Locale";
+import { Language, Languages } from "../../context/Locale";
 
 import type { SyncUpdateAction } from "./sync";
 
@@ -25,6 +25,10 @@ export function findLanguage(lang?: string): Language {
     const values = [];
     for (const key in Language) {
         const value = Language[key as keyof typeof Language];
+
+        // Skip alternative/joke languages
+        if (Languages[value].cat === "alt") continue;
+
         values.push(value);
         if (value.startsWith(code)) {
             return value as Language;


### PR DESCRIPTION
This prevents the language being automatically set to "enchantment" for English locales due to the string comparison being done with `startsWith`.