### PR TITLE
Append youtube timestamp to embed url if provided by january

### DIFF
--- a/src/components/common/messaging/embed/EmbedMedia.tsx
+++ b/src/components/common/messaging/embed/EmbedMedia.tsx
@@ -18,15 +18,22 @@ export default function EmbedMedia({ embed, width, height }: Props) {
     const client = useClient();
 
     switch (embed.special?.type) {
-        case "YouTube":
+        case "YouTube": {
+            let timestamp = "";
+
+            if (embed.special.timestamp) {
+                timestamp = `&start=${embed.special.timestamp}`;
+            }
+
             return (
                 <iframe
                     loading="lazy"
-                    src={`https://www.youtube-nocookie.com/embed/${embed.special.id}?modestbranding=1`}
+                    src={`https://www.youtube-nocookie.com/embed/${embed.special.id}?modestbranding=1${timestamp}`}
                     allowFullScreen
                     style={{ height }}
                 />
             );
+        }
         case "Twitch":
             return (
                 <iframe


### PR DESCRIPTION
This is a companion PR to https://github.com/revoltchat/january/pull/11.

It directly depends on https://github.com/revoltchat/api/pull/2. I wasn't sure on how to handle revolt-api changes in relation to revite, please let me know if there's anything else I have to do.