### PR TITLE
Choose the first channel in the server if none is selected

### DIFF
--- a/src/components/common/ServerHeader.tsx
+++ b/src/components/common/ServerHeader.tsx
@@ -5,8 +5,6 @@ import { ServerPermission } from "revolt.js/dist/api/permissions";
 import { Server } from "revolt.js/dist/maps/Servers";
 import styled from "styled-components";
 
-import { Text } from "preact-i18n";
-
 import Header from "../ui/Header";
 import IconButton from "../ui/IconButton";
 

--- a/src/components/navigation/left/ServerSidebar.tsx
+++ b/src/components/navigation/left/ServerSidebar.tsx
@@ -62,7 +62,11 @@ const ServerSidebar = observer((props: Props) => {
     if (!server) return <Redirect to="/" />;
 
     const channel = channel_id ? client.channels.get(channel_id) : undefined;
+
+    // The user selected no channel, let's see if there's a channel available
+    if (!channel && server.channel_ids.length > 0) return <Redirect to={`/server/${server_id}/channel/${server.channel_ids[0]}`} />;
     if (channel_id && !channel) return <Redirect to={`/server/${server_id}`} />;
+
     if (channel) useUnreads({ ...props, channel });
 
     useEffect(() => {


### PR DESCRIPTION
This PR adapts behaviour as such that:
* When joining a server, the first channel in the server is shown
* When deleting a channel, the first channel in the server is shown
* When opening a server on a new client for the first time, a the first channel in the server is shown
* Preserve the sidebar if no channels are available, to allow for creating a new channel (should deleting the last channel in the server be allowed at all?)