### PR TITLE
Redirect to home for empty invites

### DIFF
--- a/src/pages/RevoltApp.tsx
+++ b/src/pages/RevoltApp.tsx
@@ -121,7 +121,7 @@ export default function App() {
                         <Route path="/friends" component={Friends} />
                         <Route path="/open/:id" component={Open} />
                         <Route path="/bot/:id" component={InviteBot} />
-                        <Route path="/invite/:code" component={Invite} />
+                        <Route path="/invite/:code?" component={Invite} />
                         <Route path="/" component={Home} />
                     </Switch>
                 </Routes>

--- a/src/pages/invite/Invite.tsx
+++ b/src/pages/invite/Invite.tsx
@@ -1,6 +1,6 @@
 import { ArrowBack } from "@styled-icons/boxicons-regular";
 import { autorun } from "mobx";
-import { useHistory, useParams } from "react-router-dom";
+import { Redirect, useHistory, useParams } from "react-router-dom";
 import { RetrievedInvite } from "revolt-api/types/Invites";
 
 import styles from "./Invite.module.scss";
@@ -48,6 +48,8 @@ export default function Invite() {
                 .catch((err) => setError(takeError(err)));
         }
     }, [client, code, invite, status]);
+
+    if (code === undefined) return <Redirect to="/" />;
 
     if (typeof invite === "undefined") {
         return (


### PR DESCRIPTION
This fixes an issue wherein empty invites are not being treated as invalid and users are stuck without a left navigation panel due to invites counting as "special" routes.

Behaviour is adjusted to redirect to the homepage when an empty invite is provided.

![image](https://user-images.githubusercontent.com/16760685/132557944-23afbbd8-d436-4ac4-b4e9-7e6f2370378a.png)
