### PR TITLE
Shorten bots token dots

### DIFF
--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -352,6 +352,7 @@ function BotCard({ bot, onDelete, onUpdate }: Props) {
                     onClick={() => writeClipboard(bot.token)}
                     description={
                         <>
+                            {"••••• "}
                             <a
                                 onClick={(ev) =>
                                     stopPropagation(

--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -352,7 +352,6 @@ function BotCard({ bot, onDelete, onUpdate }: Props) {
                     onClick={() => writeClipboard(bot.token)}
                     description={
                         <>
-                            {"••••••••••••••••••••••••••••••••••••"}{" "}
                             <a
                                 onClick={(ev) =>
                                     stopPropagation(


### PR DESCRIPTION
The fake dots that resemble the bot token can sometimes make the "Reveal" button unavailable, so would be best to remove it altogether

![](https://get.snaz.in/42dzgP5.png)