### PR TITLE
FIx ping counter alignment in Firefox but actually

### DIFF
--- a/src/components/navigation/left/ServerListSidebar.tsx
+++ b/src/components/navigation/left/ServerListSidebar.tsx
@@ -66,7 +66,7 @@ function Icon({
                         text-anchor="middle"
                         fontSize={"7.5"}
                         alignmentBaseline={"middle"}
-                        dominantBaseline={"middle"}>
+                        dominant-baseline={"middle"}>
                         {count < 10 ? count : "9+"}
                     </text>
                 </>


### PR DESCRIPTION
This attribute isn't transformed into kebab-case due to a bug in Preact.