### PR TITLE
Added Copy Link inside of invites

### DIFF
--- a/src/pages/settings/server/Invites.tsx
+++ b/src/pages/settings/server/Invites.tsx
@@ -11,6 +11,7 @@ import { useClient } from "../../../context/revoltjs/RevoltClient";
 import { getChannelName } from "../../../context/revoltjs/util";
 
 import UserIcon from "../../../components/common/user/UserIcon";
+import Button from "../../../components/ui/Button";
 import IconButton from "../../../components/ui/IconButton";
 import Preloader from "../../../components/ui/Preloader";
 
@@ -60,7 +61,16 @@ export const Invites = observer(({ server }: Props) => {
                         key={invite._id}
                         className={styles.invite}
                         data-deleting={deleting.indexOf(invite._id) > -1}>
+                        <Button
+                            onClick={() => {
+                                navigator.clipboard.writeText(
+                                    `https://app.revolt.chat/invite/${invite._id}`,
+                                );
+                            }}>
+                            Copy Link
+                        </Button>
                         <code>{invite._id}</code>
+
                         <span>
                             <UserIcon target={creator} size={24} />{" "}
                             {creator?.username ?? (


### PR DESCRIPTION
This will help people copy links directly from the "Invites" page of server settings to allow them to send invite links more quickly. 