### PR TITLE
feat: Theme shop link on appearance rewrites history

### DIFF
--- a/src/pages/settings/panes/Appearance.tsx
+++ b/src/pages/settings/panes/Appearance.tsx
@@ -138,7 +138,7 @@ export function Component(props: Props) {
                 </div>
             </div>
 
-            {isExperimentEnabled('theme_shop') && <Link to="/settings/theme_shop">
+            {isExperimentEnabled('theme_shop') && <Link to="/settings/theme_shop" replace>
                 <CategoryButton icon={<Store size={24} />} action="chevron" hover>
                     <Text id="app.settings.pages.theme_shop.title" />
                 </CategoryButton>


### PR DESCRIPTION
"Theme Shop" link on Appearance won't rewrite browser history. Going in _User Settings > Appearance > Theme Shop >  Appearance > Theme Shop > Appearance > ..._ will put histories in the browser and users will have to click X multiple times to go back to the main page

Before:
![1](https://user-images.githubusercontent.com/25237131/133391666-e578a592-6c07-49cc-a88a-d45439507383.png)

After:
![2](https://user-images.githubusercontent.com/25237131/133392547-9a8479f6-b85e-422c-879a-00af1a0ce717.png)
