### PR TITLE
Allow preview actions to work with external branches / repositories

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,6 +13,10 @@ inputs:
         required: true
         default: .
 
+env:
+    BUILD_FOLDER: ${{ inputs.folder }}
+    BASE: ${{ inputs.base }}
+
 runs:
     using: composite
     steps:
@@ -22,13 +26,12 @@ runs:
               node-version: 15
               cache: "yarn"
 
-        - run: yarn install
-        # - run: yarn check
+        - name: install dependencies
+          shell: bash -l {0}
+          run: yarn install
 
         - name: build
-          env:
-              BUILD_FOLDER: ${{ inputs.folder }}
-              BASE: ${{ inputs.base }}
+          shell: bash -l {0}
           run: |
               cd "$BUILD_FOLDER"
               yarn build --base "$BASE"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,15 +22,11 @@ runs:
               node-version: 15
               cache: "yarn"
 
-        - name: install dependencies
+        - name: Install Dependencies and Build
           shell: bash -l {0}
-          run: yarn install
-
-        - name: build
           env:
               BUILD_FOLDER: ${{ inputs.folder }}
               BASE: ${{ inputs.base }}
-          shell: bash -l {0}
           run: |
-              cd "$BUILD_FOLDER"
+              yarn install
               yarn build --base "$BASE"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,10 +13,6 @@ inputs:
         required: true
         default: .
 
-env:
-    BUILD_FOLDER: ${{ inputs.folder }}
-    BASE: ${{ inputs.base }}
-
 runs:
     using: composite
     steps:
@@ -31,6 +27,9 @@ runs:
           run: yarn install
 
         - name: build
+          env:
+              BUILD_FOLDER: ${{ inputs.folder }}
+              BASE: ${{ inputs.base }}
           shell: bash -l {0}
           run: |
               cd "$BUILD_FOLDER"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -28,5 +28,6 @@ runs:
               BUILD_FOLDER: ${{ inputs.folder }}
               BASE: ${{ inputs.base }}
           run: |
+              cd "$BUILD_FOLDER"
               yarn install
               yarn build --base "$BASE"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,34 @@
+name: Build
+description: Builds a project instance, assuming all the correct project files are in the build folder
+
+inputs:
+    base:
+        name: Base path
+        description: The path to use as a base for linking
+        required: true
+        default: /
+    folder:
+        name: Build Folder
+        description: The folder to try to build from
+        required: true
+        default: .
+
+runs:
+    using: composite
+    steps:
+        - name: Setup Node
+          uses: actions/setup-node@v2
+          with:
+              node-version: 15
+              cache: "yarn"
+
+        - run: yarn install
+        # - run: yarn check
+
+        - name: build
+          env:
+              BUILD_FOLDER: ${{ inputs.folder }}
+              BASE: ${{ inputs.base }}
+          run: |
+              cd "$BUILD_FOLDER"
+              yarn build --base "$BASE"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,15 @@ on:
     pull_request:
         branches:
             - "master"
+        paths-ignore:
+            - ".github/**"
+            - "!.github/workflows/docker.yml"
+            - "!.github/workflows/preview_*.yml"
+            - ".vscode/**"
+            - ".gitignore"
+            - ".gitlab-ci.yml"
+            - "LICENSE"
+            - "README"
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
         paths-ignore:
             - ".github/**"
             - "!.github/workflows/docker.yml"
+            - "!.github/workflows/preview_*.yml"
             - ".vscode/**"
             - ".gitignore"
             - ".gitlab-ci.yml"
@@ -23,8 +24,8 @@ jobs:
     test:
         runs-on: ubuntu-latest
         strategy:
-          matrix:
-            architecture: [linux/amd64]
+            matrix:
+                architecture: [linux/amd64]
         steps:
             - name: Checkout
               uses: actions/checkout@v2
@@ -37,8 +38,8 @@ jobs:
             - name: Cache Docker layers
               uses: actions/cache@v2
               with:
-                path: /tmp/.buildx-cache/${{ matrix.architecture }}
-                key: ${{ runner.os }}-buildx-${{ matrix.architecture }}-${{ github.sha }}
+                  path: /tmp/.buildx-cache/${{ matrix.architecture }}
+                  key: ${{ runner.os }}-buildx-${{ matrix.architecture }}-${{ github.sha }}
             - name: Build
               uses: docker/build-push-action@v2
               with:
@@ -48,8 +49,8 @@ jobs:
                   cache-to: type=local,dest=/tmp/.buildx-cache-new/${{ matrix.architecture }},mode=max
             - name: Move cache
               run: |
-                rm -rf /tmp/.buildx-cache/${{ matrix.architecture }}
-                mv /tmp/.buildx-cache-new/${{ matrix.architecture }} /tmp/.buildx-cache/${{ matrix.architecture }}
+                  rm -rf /tmp/.buildx-cache/${{ matrix.architecture }}
+                  mv /tmp/.buildx-cache-new/${{ matrix.architecture }} /tmp/.buildx-cache/${{ matrix.architecture }}
 
     publish:
         needs: [test]
@@ -67,8 +68,8 @@ jobs:
             - name: Cache amd64 Docker layers
               uses: actions/cache@v2
               with:
-                path: /tmp/.buildx-cache/linux/amd64
-                key: ${{ runner.os }}-buildx-linux/amd64-${{ github.sha }}
+                  path: /tmp/.buildx-cache/linux/amd64
+                  key: ${{ runner.os }}-buildx-linux/amd64-${{ github.sha }}
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3
@@ -97,5 +98,5 @@ jobs:
                   cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
             - name: Move cache
               run: |
-               rm -rf /tmp/.buildx-cache
-               mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+                  rm -rf /tmp/.buildx-cache
+                  mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -5,7 +5,7 @@ on: [push, delete]
 jobs:
     to_gitlab:
         runs-on: ubuntu-18.04
-        if: ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}
+        if: secrets.GITLAB_SSH_PRIVATE_KEY
         steps:
             - uses: actions/checkout@v1
             - uses: pixta-dev/repository-mirroring-action@v1

--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -3,13 +3,12 @@ name: Mirroring
 on: [push, delete]
 
 jobs:
-  to_gitlab:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-    - uses: pixta-dev/repository-mirroring-action@v1
-      with:
-        target_repo_url:
-          git@gitlab.com:insert/revolt-vite.git
-        ssh_private_key:
-          ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}
+    to_gitlab:
+        runs-on: ubuntu-18.04
+        if: ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}
+        steps:
+            - uses: actions/checkout@v1
+            - uses: pixta-dev/repository-mirroring-action@v1
+              with:
+                  target_repo_url: git@gitlab.com:insert/revolt-vite.git
+                  ssh_private_key: ${{ secrets.GITLAB_SSH_PRIVATE_KEY }}

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -1,8 +1,8 @@
 name: Clean Preview
 
 #! Safety:
-#! this workflow should not execute any code at all
-#! see githubs docs on pull_request_target for more
+#! this workflow should not execute any untrusted input at all
+#! see the docs on `pull_request_target` for more
 on:
     pull_request_target:
         types: [unlabeled]

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -11,6 +11,8 @@ jobs:
     clean:
         runs-on: ubuntu-latest
         if: github.event.label.name == 'use-preview'
+        env:
+            BASE: refs/pull/${{ github.event.pull_request.number }}
 
         steps:
             - uses: actions/checkout@v2
@@ -19,7 +21,7 @@ jobs:
                   persist-credentials: false
 
             - name: clean previews
-              run: 'rm -rf "./refs/pull/${{ github.event.pull_request.number }}"'
+              run: rm -rf "$BASE"
 
             - name: publish cleaned previews
               uses: JamesIves/github-pages-deploy-action@4.1.5

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event.label.name == 'use-preview'
         env:
-            BASE: ./refs/pull/${{ github.event.pull_request.number }}
+            BASE: refs/pull/${{ github.event.pull_request.number }}
 
         steps:
             - uses: actions/checkout@v2
@@ -28,7 +28,6 @@ jobs:
               with:
                   folder: .
                   branch: build-previews
-                  single-commit: true
 
             - name: send comment
               uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -28,6 +28,7 @@ jobs:
               with:
                   folder: .
                   branch: build-previews
+                  commit-message: "Cleaning up build result for #${{ github.event.pull_request.number }}"
 
             - name: send comment
               uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         if: github.event.label.name == 'use-preview'
         env:
-            BASE: refs/pull/${{ github.event.pull_request.number }}
+            BASE: ./refs/pull/${{ github.event.pull_request.number }}
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/preview_pull_request.yml
+++ b/.github/workflows/preview_pull_request.yml
@@ -1,40 +1,43 @@
 name: Preview Pull Request
 
+#! Safety:
+#! this workflow should not execute any untrusted input at all
+#! see the docs on `pull_request_target` for more
 on:
-    pull_request:
+    pull_request_target:
         types: [synchronize, reopened, labeled]
 
 jobs:
-    build:
+    preview:
         runs-on: ubuntu-latest
         # make sure the pull request is labeled with 'use-preview'
         if: github.event.label.name == 'use-preview' || contains(github.event.pull_request.labels.*.name, 'use-preview')
+        env:
+            BASE: refs/pull/${{ github.event.pull_request.number }}/merge
+            REPO: ${{ github.event.repository.name }}
 
         steps:
+            - uses: actions/checkout@v2
+
             - uses: actions/checkout@v2
               with:
                   # Head commit of the pull request
                   ref: ${{ github.event.pull_request.head.sha }}
+                  path: pull
                   submodules: recursive
 
-            - name: Setup Node
-              uses: actions/setup-node@v2
-              with:
-                  node-version: 15
-                  cache: "yarn"
-
-            - run: yarn install
-            # - run: yarn check
-
             - name: build
-              run: yarn build --base "/revite/${{ github.ref }}/"
+              uses: ./.github/actions/build_preview
+              with:
+                  base: /${{ env.REPO }}/${{ env.BASE }}/
+                  folder: pull
 
             - name: publish preview
               uses: JamesIves/github-pages-deploy-action@4.1.5
               with:
                   folder: dist
                   branch: build-previews
-                  target-folder: ${{ github.ref }}
+                  target-folder: ${{ env.BASE }}
                   single-commit: true
 
             - name: send comment
@@ -43,6 +46,6 @@ jobs:
                   header: Preview environment
                   message: |
                       ## Preview environment
-                      https://${{ github.repository_owner }}.github.io/revite/${{ github.ref }}/
+                      https://${{ github.repository_owner }}.github.io/${{ env.REPO }}/${{ env.BASE }}/
 
                       This link will remain active until the `use-preview` label is removed.

--- a/.github/workflows/preview_pull_request.yml
+++ b/.github/workflows/preview_pull_request.yml
@@ -39,6 +39,7 @@ jobs:
                   branch: build-previews
                   target-folder: ${{ env.BASE }}
                   single-commit: true
+                  commit-message: "Publishing build result from #${{ github.event.pull_request.number }}"
 
             - name: send comment
               uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/preview_pull_request.yml
+++ b/.github/workflows/preview_pull_request.yml
@@ -35,7 +35,7 @@ jobs:
             - name: publish preview
               uses: JamesIves/github-pages-deploy-action@4.1.5
               with:
-                  folder: dist
+                  folder: pull/dist
                   branch: build-previews
                   target-folder: ${{ env.BASE }}
                   single-commit: true

--- a/.github/workflows/preview_pull_request.yml
+++ b/.github/workflows/preview_pull_request.yml
@@ -27,7 +27,7 @@ jobs:
                   submodules: recursive
 
             - name: build
-              uses: ./.github/actions/build_preview
+              uses: ./.github/actions/build
               with:
                   base: /${{ env.REPO }}/${{ env.BASE }}/
                   folder: pull


### PR DESCRIPTION
This cleans up the code of the actions, improves the safety of them, overall polishes them, and most importantly enables them to work with forked repositories and branches instead of just internal ones.

Only pull requests made after this is merged will work with the actions.