### PR TITLE
add clickable indicator for user short component

### DIFF
--- a/src/components/common/messaging/SystemMessage.tsx
+++ b/src/components/common/messaging/SystemMessage.tsx
@@ -1,24 +1,23 @@
-import {
-    InfoCircle,
-    UserPlus,
-    UserMinus,
-    ArrowToRight,
-    ArrowToLeft,
-    UserX,
-    ShieldX,
-    EditAlt,
-    Edit,
-    MessageSquareEdit,
-} from "@styled-icons/boxicons-solid";
 import { observer } from "mobx-react-lite";
+import { attachContextMenu } from "preact-context-menu";
 import { SystemMessage as SystemMessageI } from "revolt-api/types/Channels";
 import { Message } from "revolt.js/dist/maps/Messages";
 import styled from "styled-components";
 
-import { attachContextMenu } from "preact-context-menu";
+import {
+    ArrowToLeft,
+    ArrowToRight,
+    Edit,
+    EditAlt,
+    InfoCircle,
+    MessageSquareEdit,
+    ShieldX,
+    UserMinus,
+    UserPlus,
+    UserX,
+} from "@styled-icons/boxicons-solid";
 
 import { TextReact } from "../../../lib/i18n";
-
 import UserShort from "../user/UserShort";
 import MessageBase, { MessageDetail, MessageInfo } from "./MessageBase";
 

--- a/src/components/common/user/UserShort.tsx
+++ b/src/components/common/user/UserShort.tsx
@@ -1,15 +1,13 @@
 import { observer } from "mobx-react-lite";
+import { Text } from "preact-i18n";
 import { useParams } from "react-router-dom";
 import { User } from "revolt.js/dist/maps/Users";
 import styled from "styled-components";
 
-import { Text } from "preact-i18n";
-
 import { useIntermediate } from "../../../context/intermediate/Intermediate";
 import { useClient } from "../../../context/revoltjs/RevoltClient";
-
-import UserIcon from "./UserIcon";
 import { internalEmit } from "../../../lib/eventEmitter";
+import UserIcon from "./UserIcon";
 
 const BotBadge = styled.div`
     display: inline-block;
@@ -26,18 +24,42 @@ const BotBadge = styled.div`
     border-radius: calc(var(--border-radius) / 2);
 `;
 
+const Wrapper = styled.button`
+    align-items: center;
+    appearance: none;
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 2px;
+    border: 0;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background 0.25s, box-shadow 0.25s;
+
+    svg {
+        display: block;
+    }
+
+    &:hover {
+        background: rgba(0, 0, 0, 0.3);
+        box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.3);
+    }
+`;
+
+const AvatarWrapper = styled.div`
+    margin-right: 8px;
+`;
+
 type UsernameProps = JSX.HTMLAttributes<HTMLElement> & {
     user?: User;
     prefixAt?: boolean;
     showServerIdentity?: boolean;
-}
+};
 export const Username = observer(
-    ({
-        user,
-        prefixAt,
-        showServerIdentity,
-        ...otherProps
-    }: UsernameProps) => {
+    ({ user, prefixAt, showServerIdentity, ...otherProps }: UsernameProps) => {
         let username = user?.username;
         let color;
 
@@ -112,32 +134,27 @@ export default function UserShort({
 
     const handleUserClick = (e: MouseEvent) => {
         if (e.shiftKey && user?._id) {
-            e.preventDefault()
-            internalEmit(
-                "MessageBox",
-                "append",
-                `<@${user?._id}>`,
-                "mention",
-            );
+            e.preventDefault();
+            internalEmit("MessageBox", "append", `<@${user?._id}>`, "mention");
         } else {
-            openProfile()
+            openProfile();
         }
-    }
+    };
 
     return (
-        <>
-            <UserIcon
-                size={size ?? 24}
-                target={user}
-                onClick={handleUserClick}
-                showServerIdentity={showServerIdentity}
-            />
+        <Wrapper onClick={handleUserClick}>
+            <AvatarWrapper>
+                <UserIcon
+                    size={size ?? 24}
+                    target={user}
+                    showServerIdentity={showServerIdentity}
+                />
+            </AvatarWrapper>
             <Username
                 user={user}
                 showServerIdentity={showServerIdentity}
-                onClick={handleUserClick}
                 prefixAt={prefixAt}
             />
-        </>
+        </Wrapper>
     );
 }


### PR DESCRIPTION
This PR adds a few styles to indicate that the `UserShort` component can be clicked and only registers one click handler instead of two.

**Screenshots**

Default:
![image](https://user-images.githubusercontent.com/6538827/133724972-f8fba0e7-93ce-4fc6-9dbb-85f7abf1406f.png)

Hover:
![image](https://user-images.githubusercontent.com/6538827/133724996-805aa2a6-3001-4ad6-963d-6b4b509535b3.png)
