### PR TITLE
Add .idea on Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist_injected
 dist-ssr
 *.local
 *.log
+/.idea


### PR DESCRIPTION
This PR is very simple, adding .idea to gitignore for using webstorm (or an other jetbrains IDE).