### PR TITLE
Fix send message related context menu options when unable to send messages

### DIFF
--- a/src/lib/ContextMenus.tsx
+++ b/src/lib/ContextMenus.tsx
@@ -104,14 +104,14 @@ type Action =
     | { action: "create_channel"; target: Server }
     | { action: "create_category"; target: Server }
     | {
-          action: "create_invite";
-          target: Channel;
-      }
+        action: "create_invite";
+        target: Channel;
+    }
     | { action: "leave_group"; target: Channel }
     | {
-          action: "delete_channel";
-          target: Channel;
-      }
+        action: "delete_channel";
+        target: Channel;
+    }
     | { action: "close_dm"; target: Channel }
     | { action: "leave_server"; target: Server }
     | { action: "delete_server"; target: Server }
@@ -122,10 +122,10 @@ type Action =
     | { action: "open_server_settings"; id: string }
     | { action: "open_server_channel_settings"; server: string; id: string }
     | {
-          action: "set_notification_state";
-          key: string;
-          state?: NotificationState;
-      };
+        action: "set_notification_state";
+        key: string;
+        state?: NotificationState;
+    };
 
 type Props = {
     notifications: Notifications;
@@ -486,9 +486,8 @@ function ContextMenus(props: Props) {
                         elements.push(
                             <MenuItem data={action} disabled={disabled}>
                                 <Text
-                                    id={`app.context_menu.${
-                                        locale ?? action.action
-                                    }`}
+                                    id={`app.context_menu.${locale ?? action.action
+                                        }`}
                                 />
                                 {tip && <div className="tip">{tip}</div>}
                             </MenuItem>,
@@ -544,8 +543,8 @@ function ContextMenus(props: Props) {
                     const user = uid ? client.users.get(uid) : undefined;
                     const serverChannel =
                         targetChannel &&
-                        (targetChannel.channel_type === "TextChannel" ||
-                            targetChannel.channel_type === "VoiceChannel")
+                            (targetChannel.channel_type === "TextChannel" ||
+                                targetChannel.channel_type === "VoiceChannel")
                             ? targetChannel
                             : undefined;
 
@@ -557,8 +556,8 @@ function ContextMenus(props: Props) {
                         (server
                             ? server.permission
                             : serverChannel
-                            ? serverChannel.server?.permission
-                            : 0) || 0;
+                                ? serverChannel.server?.permission
+                                : 0) || 0;
                     const userPermissions = (user ? user.permission : 0) || 0;
 
                     if (unread) {
@@ -702,19 +701,27 @@ function ContextMenus(props: Props) {
                     }
 
                     if (message && !queued) {
-                        generateAction({
-                            action: "reply_message",
-                            target: message,
-                        });
+                        const sendPermission =
+                            message.channel &&
+                            message.channel.permission & ChannelPermission.SendMessage
+
+                        if (sendPermission) {
+                            generateAction({
+                                action: "reply_message",
+                                target: message,
+                            });
+                        }
 
                         if (
                             typeof message.content === "string" &&
                             message.content.length > 0
                         ) {
-                            generateAction({
-                                action: "quote_message",
-                                content: message.content,
-                            });
+                            if (sendPermission) {
+                                generateAction({
+                                    action: "quote_message",
+                                    content: message.content,
+                                });
+                            }
 
                             generateAction({
                                 action: "copy_text",
@@ -732,7 +739,7 @@ function ContextMenus(props: Props) {
                         if (
                             message.author_id === userId ||
                             channelPermissions &
-                                ChannelPermission.ManageMessages
+                            ChannelPermission.ManageMessages
                         ) {
                             generateAction({
                                 action: "delete_message",
@@ -753,8 +760,8 @@ function ContextMenus(props: Props) {
                                 type === "Image"
                                     ? "open_image"
                                     : type === "Video"
-                                    ? "open_video"
-                                    : "open_file",
+                                        ? "open_video"
+                                        : "open_file",
                             );
 
                             generateAction(
@@ -765,8 +772,8 @@ function ContextMenus(props: Props) {
                                 type === "Image"
                                     ? "save_image"
                                     : type === "Video"
-                                    ? "save_video"
-                                    : "save_file",
+                                        ? "save_video"
+                                        : "save_file",
                             );
 
                             generateAction(
@@ -880,9 +887,9 @@ function ContextMenus(props: Props) {
 
                             if (
                                 serverPermissions &
-                                    ServerPermission.ChangeNickname ||
+                                ServerPermission.ChangeNickname ||
                                 serverPermissions &
-                                    ServerPermission.ChangeAvatar
+                                ServerPermission.ChangeAvatar
                             )
                                 generateAction(
                                     { action: "edit_identity", target: server },
@@ -926,10 +933,10 @@ function ContextMenus(props: Props) {
                             sid
                                 ? "copy_sid"
                                 : cid
-                                ? "copy_cid"
-                                : message
-                                ? "copy_mid"
-                                : "copy_uid",
+                                    ? "copy_cid"
+                                    : message
+                                        ? "copy_mid"
+                                        : "copy_uid",
                         );
                     }
 


### PR DESCRIPTION


- fixes `reply` and `quote message` from appearing in the context menus for messages when unable to send messages.
- fixes #265