### PR TITLE
Invite embed improvements

### DIFF
--- a/src/components/common/messaging/embed/EmbedInvite.tsx
+++ b/src/components/common/messaging/embed/EmbedInvite.tsx
@@ -8,6 +8,7 @@ import styled, { css } from "styled-components";
 import { useContext, useEffect, useState } from "preact/hooks";
 
 import { defer } from "../../../../lib/defer";
+import { isTouchscreenDevice } from "../../../../lib/isTouchscreenDevice";
 
 import { dispatch } from "../../../../redux";
 
@@ -20,9 +21,9 @@ import { takeError } from "../../../../context/revoltjs/util";
 
 import ServerIcon from "../../../../components/common/ServerIcon";
 import Button from "../../../../components/ui/Button";
-import Preloader from "../../../ui/Preloader";
-import { isTouchscreenDevice } from "../../../../lib/isTouchscreenDevice";
 import Overline from "../../../ui/Overline";
+import Preloader from "../../../ui/Preloader";
+
 const EmbedInviteBase = styled.div`
     width: 400px;
     height: 80px;

--- a/src/components/common/messaging/embed/EmbedInvite.tsx
+++ b/src/components/common/messaging/embed/EmbedInvite.tsx
@@ -124,7 +124,7 @@ export function EmbedInvite(props: Props) {
                 <EmbedInviteDetails>
                     <EmbedInviteName>{invite.server_name}</EmbedInviteName>
                     <EmbedInviteMemberCount>
-                        {invite.member_count.toLocaleString()} members
+                        {invite.member_count.toLocaleString()} {invite.member_count === 1 ? "member" : "members"}
                     </EmbedInviteMemberCount>
                 </EmbedInviteDetails>
                 {processing ? (


### PR DESCRIPTION
- Fixed mobile display issues
- Add line limit for very long server names
- Display join errors below embed
- Keep spinner on button click until server is joined
- Show "member" instead of "members" on invites with only 1 member

(screenshot with devtools mobile web emulator active and invite URLs blocked)
![image](https://user-images.githubusercontent.com/31465218/134228104-a5c4befe-dc84-4f44-a181-34041c242127.png)
