### PR TITLE
Add linebreak before logo

### DIFF
--- a/src/context/intermediate/modals/Onboarding.tsx
+++ b/src/context/intermediate/modals/Onboarding.tsx
@@ -40,6 +40,7 @@ export function OnboardingModal({ onClose, callback }: Props) {
             <div className={styles.header}>
                 <h1>
                     <Text id="app.special.modals.onboarding.welcome" />
+                    <br />
                     <img src={wideSVG} loading="eager" />
                 </h1>
             </div>

--- a/src/pages/channels/messaging/ConversationStart.tsx
+++ b/src/pages/channels/messaging/ConversationStart.tsx
@@ -30,7 +30,13 @@ export default observer(({ channel }: Props) => {
         <StartBase>
             <h1>{getChannelName(channel, true)}</h1>
             <h4>
-                <Text id="app.main.channel.start.group" />
+                <Text
+                    id={
+                        channel.channel_type === "SavedMessages"
+                            ? "app.main.channel.start.saved"
+                            : "app.main.channel.start.group"
+                    }
+                />
             </h4>
         </StartBase>
     );


### PR DESCRIPTION
Adds a linebreak before the logo on the onboarding modal.

**New:**
<img width="200" alt="Capture2" src="https://user-images.githubusercontent.com/34319439/134359019-afb1492b-0835-4bc6-9bc4-258ce42ae558.PNG">
**Old:**
<img width="363" alt="Capture" src="https://user-images.githubusercontent.com/34319439/134359028-b404c387-f489-485c-9356-00cd9c69b530.PNG">
