### PR TITLE
Add linebreak before onboarding logo

### DIFF
--- a/src/context/intermediate/modals/Onboarding.tsx
+++ b/src/context/intermediate/modals/Onboarding.tsx
@@ -40,6 +40,7 @@ export function OnboardingModal({ onClose, callback }: Props) {
             <div className={styles.header}>
                 <h1>
                     <Text id="app.special.modals.onboarding.welcome" />
+                    <br />
                     <img src={wideSVG} loading="eager" />
                 </h1>
             </div>


### PR DESCRIPTION
Adds a linebreak before the logo on the onboarding modal.

**New:**
<img width="200" alt="Capture2" src="https://user-images.githubusercontent.com/34319439/134359019-afb1492b-0835-4bc6-9bc4-258ce42ae558.PNG">
**Old:**
<img width="363" alt="Capture" src="https://user-images.githubusercontent.com/34319439/134359028-b404c387-f489-485c-9356-00cd9c69b530.PNG">
