### PR TITLE
[fix] Show "Category Name" instead of "Channel Name" when creating Category

### DIFF
--- a/src/context/intermediate/modals/Prompt.tsx
+++ b/src/context/intermediate/modals/Prompt.tsx
@@ -503,7 +503,7 @@ export const SpecialPromptModal = observer((props: SpecialProps) => {
                     content={
                         <>
                             <Overline block type="subtle">
-                                <Text id="app.main.servers.channel_name" />
+                                <Text id="app.main.servers.category_name" />
                             </Overline>
                             <InputBox
                                 value={name}


### PR DESCRIPTION
before
<img width="389" alt="CleanShot 2021-09-23 at 22 36 53@2x" src="https://user-images.githubusercontent.com/32676955/134623671-95c332ff-7d25-41f5-90ba-629bca3284bf.png">


after (in conjuction with https://github.com/revoltchat/translations/pull/14)

<img width="450" alt="CleanShot 2021-09-23 at 22 34 57@2x" src="https://user-images.githubusercontent.com/32676955/134623591-f60f3219-cdf6-43ba-9cc0-57ed142954ce.png">
