### PR TITLE
feat: require at least two characters to autocomplete emoji

### DIFF
--- a/src/components/common/AutoComplete.tsx
+++ b/src/components/common/AutoComplete.tsx
@@ -14,19 +14,19 @@ import UserIcon from "./user/UserIcon";
 export type AutoCompleteState =
     | { type: "none" }
     | ({ selected: number; within: boolean } & (
-          | {
-                type: "emoji";
-                matches: string[];
-            }
-          | {
-                type: "user";
-                matches: User[];
-            }
-          | {
-                type: "channel";
-                matches: Channel[];
-            }
-      ));
+        | {
+            type: "emoji";
+            matches: string[];
+        }
+        | {
+            type: "user";
+            matches: User[];
+        }
+        | {
+            type: "channel";
+            matches: Channel[];
+        }
+    ));
 
 export type SearchClues = {
     users?: { type: "channel"; id: string } | { type: "all" };
@@ -79,13 +79,15 @@ export function useAutoComplete(
 
             if (current === ":" || current === "@" || current === "#") {
                 const search = content.slice(j + 1, content.length);
-                if (search.length > 0) {
+                const minLen = current === ":" ? 2 : 1
+
+                if (search.length >= minLen) {
                     return [
                         current === "#"
                             ? "channel"
                             : current === ":"
-                            ? "emoji"
-                            : "user",
+                                ? "emoji"
+                                : "user",
                         search.toLowerCase(),
                         j + 1,
                     ];
@@ -165,8 +167,8 @@ export function useAutoComplete(
                 const matches = (
                     search.length > 0
                         ? users.filter((user) =>
-                              user.username.toLowerCase().match(regex),
-                          )
+                            user.username.toLowerCase().match(regex),
+                        )
                         : users
                 )
                     .splice(0, 5)
@@ -197,8 +199,8 @@ export function useAutoComplete(
                 const matches = (
                     search.length > 0
                         ? channels.filter((channel) =>
-                              channel.name!.toLowerCase().match(regex),
-                          )
+                            channel.name!.toLowerCase().match(regex),
+                        )
                         : channels
                 )
                     .splice(0, 5)
@@ -415,7 +417,7 @@ export default function AutoComplete({
                             <Emoji
                                 emoji={
                                     (emojiDictionary as Record<string, string>)[
-                                        match
+                                    match
                                     ]
                                 }
                                 size={20}


### PR DESCRIPTION
- why? it makes typing `:3` easier