### PR TITLE
feat: add delete server button to server settings

### DIFF
--- a/src/context/intermediate/modals/Prompt.tsx
+++ b/src/context/intermediate/modals/Prompt.tsx
@@ -155,8 +155,6 @@ export const SpecialPromptModal = observer((props: SpecialProps) => {
                                         case "leave_group":
                                         case "close_dm":
                                         case "delete_channel":
-                                            props.target.delete();
-                                            break;
                                         case "leave_server":
                                         case "delete_server":
                                             props.target.delete();

--- a/src/pages/settings/ServerSettings.tsx
+++ b/src/pages/settings/ServerSettings.tsx
@@ -1,15 +1,24 @@
-import { ListUl, ListCheck, ListMinus } from "@styled-icons/boxicons-regular";
+import {
+    ListUl,
+    ListCheck,
+    ListMinus,
+    Trash,
+} from "@styled-icons/boxicons-regular";
 import { XSquare, Share, Group } from "@styled-icons/boxicons-solid";
 import { observer } from "mobx-react-lite";
 import { Route, Switch, useHistory, useParams } from "react-router-dom";
 
+import styles from "./Settings.module.scss";
 import { Text } from "preact-i18n";
 
+import { useIntermediate } from "../../context/intermediate/Intermediate";
 import RequiresOnline from "../../context/revoltjs/RequiresOnline";
 import { useClient } from "../../context/revoltjs/RevoltClient";
 
 import Category from "../../components/ui/Category";
+import LineDivider from "../../components/ui/LineDivider";
 
+import ButtonItem from "../../components/navigation/items/ButtonItem";
 import { GenericSettings } from "./GenericSettings";
 import { Bans } from "./server/Bans";
 import { Categories } from "./server/Categories";
@@ -19,11 +28,13 @@ import { Overview } from "./server/Overview";
 import { Roles } from "./server/Roles";
 
 export default observer(() => {
+    const { openScreen } = useIntermediate();
     const { server: sid } = useParams<{ server: string }>();
     const client = useClient();
     const server = client.servers.get(sid);
     if (!server) return null;
 
+    const owner = server.owner === client.user?._id;
     const history = useHistory();
     function switchPage(to?: string) {
         if (to) {
@@ -111,6 +122,26 @@ export default observer(() => {
             category="server_pages"
             switchPage={switchPage}
             defaultPage="overview"
+            custom={
+                owner ? (
+                    <>
+                        <LineDivider />
+                        <ButtonItem
+                            onClick={() =>
+                                openScreen({
+                                    id: "special_prompt",
+                                    type: "delete_server",
+                                    target: server,
+                                })
+                            }
+                            className={styles.logOut}
+                            compact>
+                            <Trash size={20} />
+                            <Text id="app.context_menu.delete_server" />
+                        </ButtonItem>
+                    </>
+                ) : undefined
+            }
             showExitButton
         />
     );

--- a/src/pages/settings/ServerSettings.tsx
+++ b/src/pages/settings/ServerSettings.tsx
@@ -134,7 +134,7 @@ export default observer(() => {
                                     target: server,
                                 })
                             }
-                            className={styles.logOut}
+                            className={styles.deleteServer}
                             compact>
                             <Trash size={20} />
                             <Text id="app.context_menu.delete_server" />

--- a/src/pages/settings/Settings.module.scss
+++ b/src/pages/settings/Settings.module.scss
@@ -144,7 +144,9 @@
         .donate {
             color: goldenrod !important;
         }
-        .logOut {
+
+        .logOut,
+        .deleteServer {
             color: var(--error) !important;
         }
 


### PR DESCRIPTION
## Description
This PR adds a button to the server settings menu to delete said server. This only shows if the user is the server owner.
## NOTE
Currently, while the server is deleted the user is not redirected to the home page. I've tried `history.push("/")` to no avail - any ideas?
## Screenshots
![image](https://user-images.githubusercontent.com/42586271/140088333-1b34603e-3e52-42e6-923a-053cc9a0962e.png)
