### PR TITLE
More translation strings

### DIFF
--- a/src/pages/settings/panes/Account.tsx
+++ b/src/pages/settings/panes/Account.tsx
@@ -157,22 +157,23 @@ export const Account = observer(() => {
             </h3>
             <h5>
                 {/*<Text id="app.settings.pages.account.2fa.description" />*/}
-                Two-factor authentication is currently work-in-progress, see{" "}
+                <Text id="app.settings.pages.account.2fa.wip" />
                 {` `}
                 <a
                     href="https://github.com/insertish/rauth/milestone/1"
                     target="_blank"
                     rel="noreferrer">
-                    v1 milestone here
+                    <Text id="app.settings.pages.account.2fa.wip_link" />
                 </a>
-                .
             </h5>
             <CategoryButton
                 icon={<Lock size={24} color="var(--error)" />}
-                description={"Set up 2FA Authentication on your account."}
+                description={
+                    <Text id="app.settings.pages.account.2fa.setup_description" />
+                }
                 disabled
                 action="chevron">
-                Set up Two-factor authentication
+                <Text id="app.settings.pages.account.2fa.setup" />
             </CategoryButton>
             <h3>
                 <Text id="app.settings.pages.account.manage.title" />
@@ -183,7 +184,7 @@ export const Account = observer(() => {
             <CategoryButton
                 icon={<Block size={24} color="var(--error)" />}
                 description={
-                    "Disable your account. You won't be able to access it unless you log back in."
+                    <Text id="app.settings.pages.account.manage.disable_description" />
                 }
                 disabled
                 action={<Text id="general.unavailable" />}>
@@ -193,7 +194,7 @@ export const Account = observer(() => {
                 <CategoryButton
                     icon={<Trash size={24} color="var(--error)" />}
                     description={
-                        "Delete your account, including all of your data. (sends an email to contact@revolt.chat)"
+                        <Text id="app.settings.pages.account.manage.delete_description" />
                     }
                     hover
                     action="external">

--- a/src/pages/settings/panes/Appearance.tsx
+++ b/src/pages/settings/panes/Appearance.tsx
@@ -1,5 +1,6 @@
 import { Reset, Import } from "@styled-icons/boxicons-regular";
 import { Pencil, Store } from "@styled-icons/boxicons-solid";
+import { Link } from "react-router-dom";
 // @ts-expect-error shade-blend-color does not have typings.
 import pSBC from "shade-blend-color";
 
@@ -8,15 +9,12 @@ import { Text } from "preact-i18n";
 import { useCallback, useContext, useEffect, useState } from "preact/hooks";
 
 import TextAreaAutoSize from "../../../lib/TextAreaAutoSize";
-import CategoryButton from "../../../components/ui/fluent/CategoryButton";
-
-
 import { debounce } from "../../../lib/debounce";
 
 import { dispatch } from "../../../redux";
 import { connectState } from "../../../redux/connector";
+import { isExperimentEnabled } from "../../../redux/reducers/experiments";
 import { EmojiPacks, Settings } from "../../../redux/reducers/settings";
-
 
 import {
     DEFAULT_FONT,
@@ -40,14 +38,13 @@ import Checkbox from "../../../components/ui/Checkbox";
 import ColourSwatches from "../../../components/ui/ColourSwatches";
 import ComboBox from "../../../components/ui/ComboBox";
 import InputBox from "../../../components/ui/InputBox";
+import CategoryButton from "../../../components/ui/fluent/CategoryButton";
 import darkSVG from "../assets/dark.svg";
 import lightSVG from "../assets/light.svg";
 import mutantSVG from "../assets/mutant_emoji.svg";
 import notoSVG from "../assets/noto_emoji.svg";
 import openmojiSVG from "../assets/openmoji_emoji.svg";
 import twemojiSVG from "../assets/twemoji_emoji.svg";
-import { Link } from "react-router-dom";
-import { isExperimentEnabled } from "../../../redux/reducers/experiments";
 
 interface Props {
     settings: Settings;
@@ -112,8 +109,7 @@ export function Component(props: Props) {
                         draggable={false}
                         data-active={selected === "light"}
                         onClick={() =>
-                            selected !== "light" &&
-                            setTheme({ base: "light" })
+                            selected !== "light" && setTheme({ base: "light" })
                         }
                         onContextMenu={(e) => e.preventDefault()}
                     />
@@ -138,11 +134,16 @@ export function Component(props: Props) {
                 </div>
             </div>
 
-            {isExperimentEnabled('theme_shop') && <Link to="/settings/theme_shop" replace>
-                <CategoryButton icon={<Store size={24} />} action="chevron" hover>
-                    <Text id="app.settings.pages.theme_shop.title" />
-                </CategoryButton>
-            </Link>}
+            {isExperimentEnabled("theme_shop") && (
+                <Link to="/settings/theme_shop" replace>
+                    <CategoryButton
+                        icon={<Store size={24} />}
+                        action="chevron"
+                        hover>
+                        <Text id="app.settings.pages.theme_shop.title" />
+                    </CategoryButton>
+                </Link>
+            )}
 
             <h3>
                 <Text id="app.settings.pages.appearance.accent_selector" />
@@ -330,7 +331,9 @@ export function Component(props: Props) {
                         </Button>
                     </Tooltip>
                 </div>
-                <h3>App</h3>
+                <h3>
+                    <Text id="app.settings.pages.appearance.app" />
+                </h3>
                 <div className={styles.overrides}>
                     {(
                         [

--- a/src/pages/settings/panes/Experiments.tsx
+++ b/src/pages/settings/panes/Experiments.tsx
@@ -1,6 +1,8 @@
 import styles from "./Panes.module.scss";
 import { Text } from "preact-i18n";
 
+import { useTranslation } from "../../../lib/i18n";
+
 import { dispatch } from "../../../redux";
 import { connectState } from "../../../redux/connector";
 import {
@@ -17,6 +19,8 @@ interface Props {
 }
 
 export function Component(props: Props) {
+    const translate = useTranslation();
+
     return (
         <div className={styles.experiments}>
             <h3>
@@ -34,8 +38,18 @@ export function Component(props: Props) {
                             key,
                         })
                     }
-                    description={EXPERIMENTS[key].description}>
-                    {EXPERIMENTS[key].title}
+                    description={translate(
+                        `app.settings.pages.experiments.${key}.description`,
+                        undefined,
+                        undefined,
+                        EXPERIMENTS[key].description,
+                    )}>
+                    {translate(
+                        `app.settings.pages.experiments.${key}.title`,
+                        undefined,
+                        undefined,
+                        EXPERIMENTS[key].title,
+                    )}
                 </Checkbox>
             ))}
             {AVAILABLE_EXPERIMENTS.length === 0 && (

--- a/src/pages/settings/panes/Native.tsx
+++ b/src/pages/settings/panes/Native.tsx
@@ -1,3 +1,4 @@
+import { Text } from "preact-i18n";
 import { useEffect, useState } from "preact/hooks";
 
 import Button from "../../../components/ui/Button";
@@ -18,8 +19,12 @@ export function Native() {
 
     return (
         <div>
-            <h3>App Behavior</h3>
-            <h5>Some options might require a restart.</h5>
+            <h3>
+                <Text id="app.settings.pages.native.app_behavior" />
+            </h3>
+            <h5>
+                <Text id="app.settings.pages.native.tip_restart" />
+            </h5>
             <Checkbox
                 checked={autoStart ?? false}
                 disabled={typeof autoStart === "undefined"}
@@ -32,8 +37,10 @@ export function Native() {
 
                     setAutoStart(v);
                 }}
-                description="Launch Revolt when you log into your computer.">
-                Start with computer
+                description={
+                    <Text id="app.settings.pages.native.description.start_with_computer" />
+                }>
+                <Text id="app.settings.pages.native.option.start_with_computer" />
             </Checkbox>
 
             <Checkbox
@@ -45,8 +52,10 @@ export function Native() {
                         discordRPC,
                     });
                 }}
-                description="Rep Revolt on your Discord status.">
-                Enable Discord status
+                description={
+                    <Text id="app.settings.pages.native.description.discord_status" />
+                }>
+                <Text id="app.settings.pages.native.option.discord_status" />
             </Checkbox>
             <Checkbox
                 checked={config.build === "nightly"}
@@ -59,10 +68,14 @@ export function Native() {
                         build,
                     });
                 }}
-                description="Use the beta branch of Revolt.">
-                Revolt Nightly
+                description={
+                    <Text id="app.settings.pages.native.description.nightly" />
+                }>
+                <Text id="app.settings.pages.native.option.nightly" />
             </Checkbox>
-            <h3>Titlebar</h3>
+            <h3>
+                <Text id="app.settings.pages.native.titlebar" />
+            </h3>
             <Checkbox
                 checked={!config.frame}
                 onChange={(frame) => {
@@ -73,8 +86,10 @@ export function Native() {
                         frame: !frame,
                     });
                 }}
-                description={<>Let Revolt use its own window frame.</>}>
-                Custom window frame
+                description={
+                    <Text id="app.settings.pages.native.description.custom_window_frame" />
+                }>
+                <Text id="app.settings.pages.native.option.custom_window_frame" />
             </Checkbox>
             <Checkbox //FIXME: In Titlebar.tsx, enable .quick css
                 disabled={true}
@@ -87,10 +102,14 @@ export function Native() {
                         frame: !frame,
                     });
                 }}
-                description="Show mute/deafen buttons on the titlebar.">
-                Enable quick action buttons
+                description={
+                    <Text id="app.settings.pages.native.description.quick_action_btn" />
+                }>
+                <Text id="app.settings.pages.native.option.quick_action_btn" />
             </Checkbox>
-            <h3>Advanced</h3>
+            <h3>
+                <Text id="app.settings.pages.native.advanced" />
+            </h3>
             <Checkbox
                 checked={config.hardwareAcceleration}
                 onChange={async (hardwareAcceleration) => {
@@ -104,8 +123,10 @@ export function Native() {
                         hardwareAcceleration,
                     });
                 }}
-                description="Uses your GPU to render the app, disable if you run into visual issues.">
-                Hardware Acceleration
+                description={
+                    <Text id="app.settings.pages.native.description.hardware_accel" />
+                }>
+                <Text id="app.settings.pages.native.option.hardware_accel" />
             </Checkbox>
             <p style={{ display: "flex", gap: "8px" }}>
                 <Button
@@ -113,20 +134,24 @@ export function Native() {
                     compact
                     disabled={!hintReload}
                     onClick={window.native.reload}>
-                    Reload Page
+                    <Text id="app.settings.pages.native.reload_page" />
                 </Button>
                 <Button
                     contrast
                     compact
                     disabled={!hintRelaunch}
                     onClick={window.native.relaunch}>
-                    Reload App
+                    <Text id="app.settings.pages.native.reload_app" />
                 </Button>
             </p>
-            <h3 style={{ marginTop: "4em" }}>Local Development Mode</h3>
+            <h3 style={{ marginTop: "4em" }}>
+                <Text id="app.settings.pages.native.local_dev_mode" />
+            </h3>
             {config.build === "dev" ? (
                 <>
-                    <h5>Development mode is currently on.</h5>
+                    <h5>
+                        <Text id="app.settings.pages.native.dev_mode_currently_on" />
+                    </h5>
                     <Button
                         contrast
                         compact
@@ -134,7 +159,7 @@ export function Native() {
                             window.native.set("build", "stable");
                             window.native.reload();
                         }}>
-                        Exit Development Mode
+                        <Text id="app.settings.pages.native.exit_dev_mode" />
                     </Button>
                 </>
             ) : (
@@ -144,19 +169,17 @@ export function Native() {
                         onChange={setConfirmDev}
                         description={
                             <>
-                                This will change the app to the 'dev' branch,
-                                instead loading the app from a local server on
-                                your machine.
+                                <Text id="app.settings.pages.native.local_dev_option_description" />
                                 <br />
                                 <b>
-                                    Without a server running,{" "}
+                                    <Text id="app.settings.pages.native.local_dev_option_desc_without_running" />{" "}
                                     <span style={{ color: "var(--error)" }}>
-                                        the app will not load!
+                                        <Text id="app.settings.pages.native.local_dev_option_desc_wont_load" />
                                     </span>
                                 </b>
                             </>
                         }>
-                        I understand there's no going back.
+                        <Text id="app.settings.pages.native.local_dev_option_title" />
                     </Checkbox>
                     <p>
                         <Button
@@ -167,7 +190,7 @@ export function Native() {
                                 window.native.set("build", "dev");
                                 window.native.reload();
                             }}>
-                            Enter Development Mode
+                            <Text id="app.settings.pages.native.enter_dev_mode" />
                         </Button>
                     </p>
                 </>

--- a/src/pages/settings/panes/ThemeShop.tsx
+++ b/src/pages/settings/panes/ThemeShop.tsx
@@ -179,7 +179,7 @@ export function ThemeShop() {
     return (
         <ThemeShopRoot>
             <Tip warning hideSeparator>
-                <Text id="app.settings.pages.theme_shop.under_construction_warning" />
+                This section is under construction.
             </Tip>
             <ThemeList>
                 {themeList?.map(([slug, theme]) => (

--- a/src/pages/settings/panes/ThemeShop.tsx
+++ b/src/pages/settings/panes/ThemeShop.tsx
@@ -1,10 +1,13 @@
 import styled from "styled-components";
 
+import { Text } from "preact-i18n";
 import { useEffect, useState } from "preact/hooks";
+
+import { TextReact } from "../../../lib/i18n";
 
 import { dispatch } from "../../../redux";
 
-import { Theme, generateVariables, ThemeOptions } from "../../../context/Theme";
+import { Theme, generateVariables } from "../../../context/Theme";
 
 import Tip from "../../../components/ui/Tip";
 import previewPath from "../assets/preview.svg";
@@ -176,7 +179,7 @@ export function ThemeShop() {
     return (
         <ThemeShopRoot>
             <Tip warning hideSeparator>
-                This section is under construction.
+                <Text id="app.settings.pages.theme_shop.under_construction_warning" />
             </Tip>
             <ThemeList>
                 {themeList?.map(([slug, theme]) => (
@@ -185,7 +188,12 @@ export function ThemeShop() {
                         data-loaded={Reflect.has(themeData, slug)}>
                         <h2 class="name">{theme.name}</h2>
                         {/* Maybe id's of the users should be included as well / instead? */}
-                        <div class="creator">by {theme.creator}</div>
+                        <div class="creator">
+                            <TextReact
+                                id="app.settings.pages.theme_shop.creator"
+                                fields={{ creator: theme.creator }}
+                            />
+                        </div>
                         <div class="description">{theme.description}</div>
                         <button
                             class="preview"
@@ -195,9 +203,9 @@ export function ThemeShop() {
                                     theme: {
                                         slug,
                                         meta: theme,
-                                        theme: themeData[slug]
-                                    }
-                                })
+                                        theme: themeData[slug],
+                                    },
+                                });
 
                                 dispatch({
                                     type: "SETTINGS_SET_THEME",


### PR DESCRIPTION
This PR introduces supports for additional translation strings for 5 setting pages

- [x] Account setting translation strings
- [x] Experiment setting translation strings
- [x] Theme shop translation strings
- [x] Appearance setting translation strings
- [x] Native setting translation strings

Linked PR: https://github.com/revoltchat/translations/pull/21