### PR TITLE
chore: rename the string for previewing the profile page

### DIFF
--- a/src/pages/settings/panes/Profile.tsx
+++ b/src/pages/settings/panes/Profile.tsx
@@ -62,7 +62,7 @@ export const Profile = observer(() => {
     return (
         <div className={styles.user}>
             <h3>
-                <Text id="app.special.modals.actions.preview" />
+                <Text id="app.settings.pages.profile.preview" />
             </h3>
             <div className={styles.preview}>
                 <UserProfile


### PR DESCRIPTION
The toki pona translation of this string only makes sense on the profile
page, and wouldn't make sense if used as an action button. This is to
reduce the chance of the string being used in other contexts.