### PR TITLE
fix: added hover event to overline + removed context menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
             rel="apple-touch-startup-image"
         />
     </head>
-    <body ontouchstart="">
+    <body onContextMenu="return false" ontouchstart="">
         <div id="app"></div>
         <script type="module" src="/src/main.tsx"></script>
     </body>

--- a/src/components/navigation/right/Search.tsx
+++ b/src/components/navigation/right/Search.tsx
@@ -102,7 +102,7 @@ export function SearchSidebar({ close }: Props) {
         <GenericSidebarBase>
             <GenericSidebarList>
                 <SearchBase>
-                    <Overline type="error" onClick={close} block>
+                    <Overline type="error" onClick={close} block hoverEnabled>
                         « back to members
                     </Overline>
                     <Overline type="subtle" block>

--- a/src/components/ui/Overline.tsx
+++ b/src/components/ui/Overline.tsx
@@ -5,6 +5,7 @@ import { Text } from "preact-i18n";
 import { Children } from "../../types/Preact";
 
 type Props = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "as"> & {
+    hoverEnabled?: boolean;
     error?: string;
     block?: boolean;
     spaced?: boolean;
@@ -15,6 +16,18 @@ type Props = Omit<JSX.HTMLAttributes<HTMLDivElement>, "children" | "as"> & {
 
 const OverlineBase = styled.div<Omit<Props, "children" | "error">>`
     display: inline;
+    transition: 0.2s ease filter;
+
+    ${(props) =>
+        props.hoverEnabled &&
+        css`
+            &:hover {
+                filter: brightness(1.2);
+                cursor: pointer;
+
+                transition: 0.2s ease filter;
+            }
+        `}
 
     ${(props) =>
         !props.noMargin &&


### PR DESCRIPTION
Use prop `hoverEnabled` to enable the hover event for an Overline element.

Specifically enabled this for the back to members button in the search panel!
This fixes issue #286.

Fixes #286.
Fixes #343.