### PR TITLE
fix(ui): flicker on modal close

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -53,6 +53,7 @@ const ModalBase = styled.div`
 
     &.closing {
         animation-name: ${close};
+        animation-fill-mode: forwards;
     }
 
     &.closing > div {


### PR DESCRIPTION
There is a race condition between the animation finishing and the modal being removed from the div, meaning that if the animation finishes first, it will return back to the default state. The 'animation-fill-mode: forwards' makes the animation stop at its final stage.