### PR TITLE
fix: make the category name input use --font

### DIFF
--- a/src/pages/settings/server/Categories.tsx
+++ b/src/pages/settings/server/Categories.tsx
@@ -97,6 +97,10 @@ const KanbanListHeader = styled.div`
     cursor: pointer !important;
     transition: 0.2s ease background-color;
 
+    > * {
+        font: var(--font);
+    }
+
     &:hover {
         background: var(--background);
     }


### PR DESCRIPTION
begone, arial

## Screenshots

![image](https://user-images.githubusercontent.com/42586271/142942578-fa6b4357-c903-4b66-8e5a-096f6855a657.png)
