### PR TITLE
Fixed conditions for "Manage {Server,Channel}" buttons to appear

### DIFF
--- a/src/components/common/ServerHeader.tsx
+++ b/src/components/common/ServerHeader.tsx
@@ -125,7 +125,7 @@ export default observer(({ server }: Props) => {
                     </Tooltip>
                 ) : undefined}
                 <div className="title">{server.name}</div>
-                {(server.permission & ServerPermission.ManageServer) > 0 && (
+                {shouldShowSettingIcon() && (
                     <Link to={`/server/${server._id}/settings`}>
                         <IconButton>
                             <Cog size={20} />
@@ -135,4 +135,17 @@ export default observer(({ server }: Props) => {
             </div>
         </ServerBanner>
     );
+
+    function shouldShowSettingIcon() {
+        for (const perm of [
+            ServerPermission.ManageServer,
+            ServerPermission.BanMembers,
+            ServerPermission.ManageRoles,
+            ServerPermission.ManageChannels,
+        ]) {
+            if ((server.permission & perm) > 0) return true;
+        }
+
+        return false;
+    }
 });

--- a/src/components/navigation/items/ButtonItem.tsx
+++ b/src/components/navigation/items/ButtonItem.tsx
@@ -219,6 +219,7 @@ type ButtonProps = CommonProps & {
     children?: Children;
     className?: string;
     compact?: boolean;
+    disabled?: boolean;
 };
 
 export default function ButtonItem(props: ButtonProps) {
@@ -241,7 +242,12 @@ export default function ButtonItem(props: ButtonProps) {
                 { [styles.compact]: compact, [styles.normal]: !compact },
                 className,
             )}
-            onClick={onClick}
+            style={
+                props.disabled
+                    ? "filter: grayscale(70%) brightness(70%);"
+                    : undefined
+            }
+            onClick={() => !props.disabled && onClick && onClick()}
             data-active={active}
             data-alert={typeof alert === "string"}>
             <div className={styles.content}>{children}</div>

--- a/src/lib/ContextMenus.tsx
+++ b/src/lib/ContextMenus.tsx
@@ -517,7 +517,19 @@ export default function ContextMenus() {
                                     target: server,
                                 });
                             }
-                            if (permissions & ServerPermission.ManageServer)
+
+                            const shouldShowSettings = () => {
+                                for (const perm of [
+                                    ServerPermission.ManageServer,
+                                    ServerPermission.BanMembers,
+                                    ServerPermission.ManageRoles,
+                                    ServerPermission.ManageChannels,
+                                ]) {
+                                    if ((permissions & perm) > 0) return true;
+                                }
+                            };
+
+                            if (shouldShowSettings())
                                 generateAction({
                                     action: "open_server_settings",
                                     id: server_list,
@@ -968,10 +980,19 @@ export default function ContextMenus() {
                                     "edit_identity",
                                 );
 
-                            if (
-                                serverPermissions &
-                                ServerPermission.ManageServer
-                            )
+                            const shouldShowSettings = () => {
+                                for (const perm of [
+                                    ServerPermission.ManageServer,
+                                    ServerPermission.BanMembers,
+                                    ServerPermission.ManageRoles,
+                                    ServerPermission.ManageChannels,
+                                ]) {
+                                    if ((serverPermissions & perm) > 0)
+                                        return true;
+                                }
+                            };
+
+                            if (shouldShowSettings())
                                 generateAction(
                                     {
                                         action: "open_server_settings",

--- a/src/lib/ContextMenus.tsx
+++ b/src/lib/ContextMenus.tsx
@@ -141,6 +141,17 @@ export default function ContextMenus() {
     const state = useApplicationState();
     const history = useHistory();
 
+    function shouldShowServerSettings(permissions: number) {
+        for (const perm of [
+            ServerPermission.ManageServer,
+            ServerPermission.BanMembers,
+            ServerPermission.ManageRoles,
+            ServerPermission.ManageChannels,
+        ]) {
+            if ((permissions & perm) > 0) return true;
+        }
+    }
+
     function contextClick(data?: Action) {
         if (typeof data === "undefined") return;
 
@@ -518,18 +529,7 @@ export default function ContextMenus() {
                                 });
                             }
 
-                            const shouldShowSettings = () => {
-                                for (const perm of [
-                                    ServerPermission.ManageServer,
-                                    ServerPermission.BanMembers,
-                                    ServerPermission.ManageRoles,
-                                    ServerPermission.ManageChannels,
-                                ]) {
-                                    if ((permissions & perm) > 0) return true;
-                                }
-                            };
-
-                            if (shouldShowSettings())
+                            if (shouldShowServerSettings(permissions))
                                 generateAction({
                                     action: "open_server_settings",
                                     id: server_list,
@@ -984,19 +984,7 @@ export default function ContextMenus() {
                                     "edit_identity",
                                 );
 
-                            const shouldShowSettings = () => {
-                                for (const perm of [
-                                    ServerPermission.ManageServer,
-                                    ServerPermission.BanMembers,
-                                    ServerPermission.ManageRoles,
-                                    ServerPermission.ManageChannels,
-                                ]) {
-                                    if ((serverPermissions & perm) > 0)
-                                        return true;
-                                }
-                            };
-
-                            if (shouldShowSettings())
+                            if (shouldShowServerSettings(serverPermissions))
                                 generateAction(
                                     {
                                         action: "open_server_settings",

--- a/src/lib/ContextMenus.tsx
+++ b/src/lib/ContextMenus.tsx
@@ -925,7 +925,9 @@ export default function ContextMenus() {
 
                                     if (
                                         serverPermissions &
-                                        ServerPermission.ManageServer
+                                            ServerPermission.ManageServer ||
+                                        channelPermissions &
+                                            ChannelPermission.ManageChannel
                                     )
                                         generateAction(
                                             {
@@ -938,7 +940,9 @@ export default function ContextMenus() {
 
                                     if (
                                         serverPermissions &
-                                        ServerPermission.ManageChannels
+                                            ServerPermission.ManageChannels ||
+                                        channelPermissions &
+                                            ChannelPermission.ManageChannel
                                     )
                                         generateAction({
                                             action: "delete_channel",

--- a/src/pages/settings/GenericSettings.tsx
+++ b/src/pages/settings/GenericSettings.tsx
@@ -158,11 +158,6 @@ export function GenericSettings({
                                                 switchPage(entry.id)
                                             }
                                             disabled={entry.disabled}
-                                            style={
-                                                entry.disabled
-                                                    ? "filter: grayscale(70%) brightness(70%);"
-                                                    : undefined
-                                            }
                                             compact>
                                             {entry.icon} {entry.title}
                                         </ButtonItem>

--- a/src/pages/settings/GenericSettings.tsx
+++ b/src/pages/settings/GenericSettings.tsx
@@ -34,6 +34,7 @@ interface Props {
         title: Children;
         hidden?: boolean;
         hideTitle?: boolean;
+        disabled?: boolean;
     }[];
     custom?: Children;
     children: Children;
@@ -152,7 +153,16 @@ export function GenericSettings({
                                                     !isTouchscreenDevice &&
                                                     typeof page === "undefined")
                                             }
-                                            onClick={() => switchPage(entry.id)}
+                                            onClick={() =>
+                                                !entry.disabled &&
+                                                switchPage(entry.id)
+                                            }
+                                            disabled={entry.disabled}
+                                            style={
+                                                entry.disabled
+                                                    ? "filter: grayscale(70%) brightness(70%);"
+                                                    : undefined
+                                            }
                                             compact>
                                             {entry.icon} {entry.title}
                                         </ButtonItem>

--- a/src/pages/settings/ServerSettings.tsx
+++ b/src/pages/settings/ServerSettings.tsx
@@ -9,6 +9,7 @@ import {
 } from "@styled-icons/boxicons-solid";
 import { observer } from "mobx-react-lite";
 import { Route, Switch, useHistory, useParams } from "react-router-dom";
+import { ServerPermission } from "revolt.js";
 
 import styles from "./Settings.module.scss";
 import { Text } from "preact-i18n";
@@ -63,12 +64,17 @@ export default observer(() => {
                     title: (
                         <Text id="app.settings.server_pages.categories.title" />
                     ),
+                    disabled:
+                        (server.permission & ServerPermission.ManageChannels) ==
+                        0,
                     hideTitle: true,
                 },
                 {
                     id: "roles",
                     icon: <FlagAlt size={20} />,
                     title: <Text id="app.settings.server_pages.roles.title" />,
+                    disabled:
+                        (server.permission & ServerPermission.ManageRoles) == 0,
                     hideTitle: true,
                 },
                 {
@@ -87,11 +93,16 @@ export default observer(() => {
                     title: (
                         <Text id="app.settings.server_pages.invites.title" />
                     ),
+                    disabled:
+                        (server.permission & ServerPermission.ManageServer) ==
+                        0,
                 },
                 {
                     id: "bans",
                     icon: <UserX size={20} />,
                     title: <Text id="app.settings.server_pages.bans.title" />,
+                    disabled:
+                        (server.permission & ServerPermission.BanMembers) == 0,
                 },
             ]}
             children={

--- a/src/pages/settings/server/Members.tsx
+++ b/src/pages/settings/server/Members.tsx
@@ -2,6 +2,7 @@ import { ChevronDown } from "@styled-icons/boxicons-regular";
 import { isEqual } from "lodash";
 import { observer } from "mobx-react-lite";
 import { Virtuoso } from "react-virtuoso";
+import { ServerPermission } from "revolt.js";
 import { Member } from "revolt.js/dist/maps/Members";
 import { Server } from "revolt.js/dist/maps/Servers";
 
@@ -31,19 +32,24 @@ const Inner = observer(({ member }: InnerProps) => {
 
     const server_roles = member.server?.roles ?? {};
     const user = member.user;
+    const canManageRoles =
+        ((member.server?.permission ?? 0) & ServerPermission.ManageRoles) > 0;
     return (
         <>
             <div
                 className={styles.member}
                 data-open={open}
-                onClick={() => setOpen(!open)}>
+                onClick={() => canManageRoles && setOpen(!open)}>
                 <span>
                     <UserIcon target={user} size={24} />{" "}
                     <Username user={member.user} showServerIdentity="both" />
                 </span>
-                <IconButton className={styles.chevron}>
-                    <ChevronDown size={24} />
-                </IconButton>
+
+                {canManageRoles && (
+                    <IconButton className={styles.chevron}>
+                        <ChevronDown size={24} />
+                    </IconButton>
+                )}
             </div>
             {open && (
                 <div className={styles.memberView}>

--- a/src/pages/settings/server/Overview.tsx
+++ b/src/pages/settings/server/Overview.tsx
@@ -1,6 +1,7 @@
 import { Markdown } from "@styled-icons/boxicons-logos";
 import isEqual from "lodash.isequal";
 import { observer } from "mobx-react-lite";
+import { ServerPermission } from "revolt.js";
 import { Server } from "revolt.js/dist/maps/Servers";
 
 import styles from "./Panes.module.scss";
@@ -50,6 +51,9 @@ export const Overview = observer(({ server }: Props) => {
         setChanged(false);
     }
 
+    const hasManagePerm =
+        (server.permission & ServerPermission.ManageServer) > 0;
+
     return (
         <div className={styles.overview}>
             <div className={styles.row}>
@@ -60,6 +64,7 @@ export const Overview = observer(({ server }: Props) => {
                     fileType="icons"
                     behaviour="upload"
                     maxFileSize={2_500_000}
+                    disabled={!hasManagePerm}
                     onUpload={(icon) => server.edit({ icon })}
                     previewURL={server.generateIconURL({ max_side: 256 }, true)}
                     remove={() => server.edit({ remove: "Icon" })}
@@ -72,6 +77,7 @@ export const Overview = observer(({ server }: Props) => {
                         contrast
                         value={name}
                         maxLength={32}
+                        disabled={!hasManagePerm}
                         onChange={(e) => {
                             setName(e.currentTarget.value);
                             if (!changed) setChanged(true);
@@ -88,6 +94,7 @@ export const Overview = observer(({ server }: Props) => {
                 minHeight={120}
                 maxLength={1024}
                 value={description}
+                disabled={!hasManagePerm}
                 placeholder={"Add a topic..."}
                 onChange={(ev) => {
                     setDescription(ev.currentTarget.value);
@@ -117,6 +124,7 @@ export const Overview = observer(({ server }: Props) => {
                 fileType="banners"
                 behaviour="upload"
                 maxFileSize={6_000_000}
+                disabled={!hasManagePerm}
                 onUpload={(banner) => server.edit({ banner })}
                 previewURL={server.generateBannerURL({ width: 1000 }, true)}
                 remove={() => server.edit({ remove: "Banner" })}
@@ -146,6 +154,7 @@ export const Overview = observer(({ server }: Props) => {
                                 key as keyof typeof systemMessages
                             ] ?? "disabled"
                         }
+                        disabled={!hasManagePerm}
                         onChange={(e) => {
                             if (!changed) setChanged(true);
                             const v = e.currentTarget.value;
@@ -181,7 +190,10 @@ export const Overview = observer(({ server }: Props) => {
             ))}
 
             <p>
-                <Button onClick={save} contrast disabled={!changed}>
+                <Button
+                    onClick={save}
+                    contrast
+                    disabled={!changed || !hasManagePerm}>
                     <Text id="app.special.modals.actions.save" />
                 </Button>
             </p>


### PR DESCRIPTION
This PR makes the "Manage Channel" context menu entry take permission overrides into consideration, and makes the "Manage Server" button appear if the user has at least one of `ManageServer`, `BanMembers`, `ManageRoles`, or `ManageChannels` permissions.

Additionally, the server settings menu now grays out and disables menu entries not available to the user.