### PR TITLE
feat: add basic navigation keybinds

### DIFF
--- a/src/components/common/AutoComplete.tsx
+++ b/src/components/common/AutoComplete.tsx
@@ -273,7 +273,7 @@ export function useAutoComplete(
         setFocused(false);
     }
 
-    keybinds.useAction(KeybindAction.NavigateAutoCompleteUp, (e) => {
+    keybinds.useAction(KeybindAction.AutoCompleteUp, (e) => {
         if (focused && state.type !== "none") {
             e.preventDefault();
 
@@ -286,7 +286,7 @@ export function useAutoComplete(
         }
     });
 
-    keybinds.useAction(KeybindAction.NavigateAutoCompleteDown, (e) => {
+    keybinds.useAction(KeybindAction.AutoCompleteDown, (e) => {
         if (focused && state.type !== "none") {
             e.preventDefault();
             if (state.selected < state.matches.length - 1) {

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../../lib/renderer/Singleton";
 
 import { useApplicationState } from "../../../mobx/State";
+import { KeybindAction } from "../../../mobx/stores/Keybinds";
 import { Reply } from "../../../mobx/stores/MessageQueue";
 
 import { useIntermediate } from "../../../context/intermediate/Intermediate";
@@ -419,6 +420,20 @@ export default observer(({ channel }: Props) => {
                 : undefined,
     });
 
+    state.keybinds.useAction(KeybindAction.EditPreviousMessage, (event) => {
+        if (!state.draft.has(channel._id)) {
+            event.preventDefault();
+            internalEmit("MessageRenderer", "edit_last");
+        }
+    });
+
+    state.keybinds.useAction(KeybindAction.InputSubmit, (e) => {
+        if (!e.isComposing && !isTouchscreenDevice) {
+            e.preventDefault();
+            send();
+        }
+    });
+
     return (
         <>
             <AutoComplete {...autoCompleteProps} />
@@ -512,25 +527,6 @@ export default observer(({ channel }: Props) => {
                         }
 
                         if (onKeyDown(e)) return;
-
-                        if (
-                            e.key === "ArrowUp" &&
-                            !state.draft.has(channel._id)
-                        ) {
-                            e.preventDefault();
-                            internalEmit("MessageRenderer", "edit_last");
-                            return;
-                        }
-
-                        if (
-                            !e.shiftKey &&
-                            !e.isComposing &&
-                            e.key === "Enter" &&
-                            !isTouchscreenDevice
-                        ) {
-                            e.preventDefault();
-                            return send();
-                        }
 
                         if (e.key === "Escape") {
                             if (replies.length > 0) {

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -414,12 +414,15 @@ export default observer(({ channel }: Props) => {
                     : undefined,
         });
 
-    state.keybinds.useAction(KeybindAction.EditPreviousMessage, (event) => {
-        if (!state.draft.has(channel._id)) {
-            event.preventDefault();
-            internalEmit("MessageRenderer", "edit_last");
-        }
-    });
+    state.keybinds.useAction(
+        KeybindAction.MessagingEditPreviousMessage,
+        (event) => {
+            if (!state.draft.has(channel._id)) {
+                event.preventDefault();
+                internalEmit("MessageRenderer", "edit_last");
+            }
+        },
+    );
 
     state.keybinds.useAction(KeybindAction.InputForceSubmit, (e) => {
         e.preventDefault();
@@ -446,6 +449,7 @@ export default observer(({ channel }: Props) => {
             });
         }
 
+        e.preventDefault();
         debouncedStopTyping(true);
     });
 

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -10,7 +10,7 @@ import { Text } from "preact-i18n";
 import { useCallback, useContext, useEffect, useState } from "preact/hooks";
 
 import TextAreaAutoSize from "../../../lib/TextAreaAutoSize";
-import { debounce } from "../../../lib/debounce";
+import { debounce, useDebounceCallback } from "../../../lib/debounce";
 import { defer } from "../../../lib/defer";
 import { internalEmit, internalSubscribe } from "../../../lib/eventEmitter";
 import { useTranslation } from "../../../lib/i18n";
@@ -399,11 +399,10 @@ export default observer(({ channel }: Props) => {
         }
     }
 
-    // TODO: change to useDebounceCallback
-    // eslint-disable-next-line
-    const debouncedStopTyping = useCallback(
-        debounce(stopTyping as (...args: unknown[]) => void, 1000),
+    const debouncedStopTyping = useDebounceCallback(
+        stopTyping,
         [channel._id],
+        1000,
     );
     const {
         onChange,

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -445,8 +445,11 @@ export default observer(({ channel }: Props) => {
     });
 
     state.keybinds.useAction(KeybindAction.InputCancel, (e) => {
+        if (!e.composedPath().includes(textAreaRef.current!)) return;
+
         if (replies.length > 0) {
             setReplies(replies.slice(0, -1));
+            e.preventDefault();
         } else if (
             uploadState.type === "attached" &&
             uploadState.files.length > 0
@@ -455,9 +458,9 @@ export default observer(({ channel }: Props) => {
                 type: uploadState.files.length > 1 ? "attached" : "none",
                 files: uploadState.files.slice(0, -1),
             });
+            e.preventDefault();
         }
 
-        e.preventDefault();
         debouncedStopTyping(true);
     });
 

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -6,6 +6,7 @@ import { Channel } from "revolt.js/dist/maps/Channels";
 import styled, { css } from "styled-components";
 import { ulid } from "ulid";
 
+import { createRef } from "preact";
 import { Text } from "preact-i18n";
 import { useCallback, useContext, useEffect, useState } from "preact/hooks";
 
@@ -414,6 +415,8 @@ export default observer(({ channel }: Props) => {
                     : undefined,
         });
 
+    const textAreaRef = createRef<HTMLDivElement>();
+
     state.keybinds.useAction(
         KeybindAction.MessagingEditPreviousMessage,
         (event) => {
@@ -430,7 +433,12 @@ export default observer(({ channel }: Props) => {
     });
 
     state.keybinds.useAction(KeybindAction.InputSubmit, (e) => {
-        if (!e.isComposing && !isTouchscreenDevice && !e.defaultPrevented) {
+        if (
+            !e.isComposing &&
+            !isTouchscreenDevice &&
+            !e.defaultPrevented &&
+            e.composedPath().includes(textAreaRef.current!)
+        ) {
             e.preventDefault();
             send();
         }
@@ -531,6 +539,7 @@ export default observer(({ channel }: Props) => {
                     </Action>
                 ) : undefined}
                 <TextAreaAutoSize
+                    innerRef={textAreaRef}
                     autoFocus
                     hideBorder
                     maxRows={20}

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -419,9 +419,13 @@ export default observer(({ channel }: Props) => {
 
     state.keybinds.useAction(
         KeybindAction.MessagingEditPreviousMessage,
-        (event) => {
-            if (!state.draft.has(channel._id)) {
-                event.preventDefault();
+        (e) => {
+            if (
+                !state.draft.has(channel._id) &&
+                !e.defaultPrevented &&
+                e.composedPath().includes(textAreaRef.current!)
+            ) {
+                e.preventDefault();
                 internalEmit("MessageRenderer", "edit_last");
             }
         },

--- a/src/components/common/messaging/bars/NewMessages.tsx
+++ b/src/components/common/messaging/bars/NewMessages.tsx
@@ -10,24 +10,23 @@ import { useEffect, useState } from "preact/hooks";
 import { internalSubscribe } from "../../../../lib/eventEmitter";
 import { getRenderer } from "../../../../lib/renderer/Singleton";
 
+import { useApplicationState } from "../../../../mobx/State";
+import { KeybindAction } from "../../../../mobx/stores/Keybinds";
+
 import { dayjs } from "../../../../context/Locale";
 
 import { Bar } from "./JumpToBottom";
 
 export default observer(
     ({ channel, last_id }: { channel: Channel; last_id?: string }) => {
+        const keybinds = useApplicationState().keybinds;
         const [hidden, setHidden] = useState(false);
         const hide = () => setHidden(true);
 
         useEffect(() => setHidden(false), [last_id]);
         useEffect(() => internalSubscribe("NewMessages", "hide", hide), []);
-        useEffect(() => {
-            const onKeyDown = (e: KeyboardEvent) =>
-                e.key === "Escape" && hide();
 
-            document.addEventListener("keydown", onKeyDown);
-            return () => document.removeEventListener("keydown", onKeyDown);
-        }, []);
+        keybinds.useAction(KeybindAction.MessagingHideNew, (e) => hide(), []);
 
         const renderer = getRenderer(channel);
         const history = useHistory();

--- a/src/components/common/messaging/bars/NewMessages.tsx
+++ b/src/components/common/messaging/bars/NewMessages.tsx
@@ -26,7 +26,11 @@ export default observer(
         useEffect(() => setHidden(false), [last_id]);
         useEffect(() => internalSubscribe("NewMessages", "hide", hide), []);
 
-        keybinds.useAction(KeybindAction.MessagingHideNew, (e) => hide(), []);
+        keybinds.useAction(
+            KeybindAction.MessagingMarkChannelRead,
+            (e) => hide(),
+            [],
+        );
 
         const renderer = getRenderer(channel);
         const history = useHistory();

--- a/src/components/navigation/LeftSidebar.tsx
+++ b/src/components/navigation/LeftSidebar.tsx
@@ -5,6 +5,7 @@ import { internalEmit } from "../../lib/eventEmitter";
 import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
 
 import { useApplicationState } from "../../mobx/State";
+import { KeybindAction } from "../../mobx/stores/Keybinds";
 import { SIDEBAR_CHANNELS } from "../../mobx/stores/Layout";
 
 import SidebarBase from "./SidebarBase";
@@ -13,29 +14,33 @@ import ServerListSidebar from "./left/ServerListSidebar";
 import ServerSidebar from "./left/ServerSidebar";
 
 export default observer(() => {
-    const layout = useApplicationState().layout;
+    const state = useApplicationState();
     const isOpen =
-        isTouchscreenDevice || layout.getSectionState(SIDEBAR_CHANNELS, true);
+        isTouchscreenDevice ||
+        state.layout.getSectionState(SIDEBAR_CHANNELS, true);
 
-    // Register events here to reduce keybind conflicts.
-    document.body.addEventListener("keydown", (e) => {
-        const emit = (event: string, direction: number) => {
-            e.preventDefault();
-            internalEmit("LeftSidebar", event, direction);
-        };
+    const emit = (event: string, direction: number) => () =>
+        internalEmit("LeftSidebar", event, direction);
 
-        if (e.ctrlKey && e.altKey && e.key === "ArrowUp")
-            return emit("navigate_servers", -1);
+    state.keybinds.useAction(
+        KeybindAction.NavigateChannelUp,
+        emit("navigate_channels", -1),
+    );
 
-        if (e.ctrlKey && e.altKey && e.key === "ArrowDown")
-            return emit("navigate_servers", 1);
+    state.keybinds.useAction(
+        KeybindAction.NavigateChannelDown,
+        emit("navigate_channels", 1),
+    );
 
-        if (e.altKey && e.key === "ArrowUp")
-            return emit("navigate_channels", -1);
+    state.keybinds.useAction(
+        KeybindAction.NavigateServerUp,
+        emit("navigate_servers", -1),
+    );
 
-        if (e.altKey && e.key === "ArrowDown")
-            return emit("navigate_channels", 1);
-    });
+    state.keybinds.useAction(
+        KeybindAction.NavigateServerDown,
+        emit("navigate_servers", 1),
+    );
 
     return (
         <SidebarBase>

--- a/src/components/navigation/LeftSidebar.tsx
+++ b/src/components/navigation/LeftSidebar.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 import { Route, Switch } from "react-router";
 
+import { internalEmit } from "../../lib/eventEmitter";
 import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
 
 import { useApplicationState } from "../../mobx/State";
@@ -15,6 +16,26 @@ export default observer(() => {
     const layout = useApplicationState().layout;
     const isOpen =
         isTouchscreenDevice || layout.getSectionState(SIDEBAR_CHANNELS, true);
+
+    // Register events here to reduce keybind conflicts.
+    document.body.addEventListener("keydown", (e) => {
+        const emit = (event: string, direction: number) => {
+            e.preventDefault();
+            internalEmit("LeftSidebar", event, direction);
+        };
+
+        if (e.ctrlKey && e.altKey && e.key === "ArrowUp")
+            return emit("navigate_servers", -1);
+
+        if (e.ctrlKey && e.altKey && e.key === "ArrowDown")
+            return emit("navigate_servers", 1);
+
+        if (e.altKey && e.key === "ArrowUp")
+            return emit("navigate_channels", -1);
+
+        if (e.altKey && e.key === "ArrowDown")
+            return emit("navigate_channels", 1);
+    });
 
     return (
         <SidebarBase>

--- a/src/components/navigation/left/ServerSidebar.tsx
+++ b/src/components/navigation/left/ServerSidebar.tsx
@@ -89,7 +89,7 @@ export default observer(() => {
         275,
     );
 
-    const channels = serverChannels(server, client);
+    const channels = serverChannels(server);
 
     useEffect(() => {
         function navigateChannels(dir: number) {

--- a/src/components/navigation/right/Search.tsx
+++ b/src/components/navigation/right/Search.tsx
@@ -106,20 +106,25 @@ export function SearchSidebar({ close }: Props) {
     }, [sort]);
 
     // needs more testing to see if this is fragile or not
+
+    // ? Search if the InputRef is being used.
     keybinds.useAction(
         KeybindAction.InputSubmit,
         (e) => {
             if (e.composedPath().includes(inputRef.current!)) {
+                e.preventDefault();
                 search();
             }
         },
         [inputRef],
     );
 
+    // ? Close search if the event came from the sidebar.
     keybinds.useAction(
         KeybindAction.InputCancel,
         (e) => {
             if (e.composedPath().includes(sidebarRef.current!)) {
+                e.preventDefault();
                 close();
             }
         },

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -5,6 +5,9 @@ import { createPortal, useCallback, useEffect, useState } from "preact/compat";
 
 import { internalSubscribe } from "../../lib/eventEmitter";
 
+import { useApplicationState } from "../../mobx/State";
+import { KeybindAction } from "../../mobx/stores/Keybinds";
+
 import { Children } from "../../types/Preact";
 import Button, { ButtonProps } from "./Button";
 
@@ -155,6 +158,7 @@ export let isModalClosing = false;
 
 export default function Modal(props: Props) {
     if (!props.visible) return null;
+    const state = useApplicationState();
 
     const content = (
         <ModalContent
@@ -180,18 +184,16 @@ export default function Modal(props: Props) {
 
     useEffect(() => internalSubscribe("Modal", "close", onClose), [onClose]);
 
-    useEffect(() => {
-        if (props.disallowClosing) return;
-
-        function keyDown(e: KeyboardEvent) {
-            if (e.key === "Escape") {
+    state.keybinds.useAction(
+        KeybindAction.NavigatePreviousContextModal,
+        (e) => {
+            if (!props.disallowClosing) {
+                e.preventDefault();
                 onClose();
             }
-        }
-
-        document.body.addEventListener("keydown", keyDown);
-        return () => document.body.removeEventListener("keydown", keyDown);
-    }, [props.disallowClosing, onClose]);
+        },
+        [props.disallowClosing, onClose],
+    );
 
     const confirmationAction = props.actions?.find(
         (action) => action.confirmation,

--- a/src/components/ui/fluent/CategoryButton.tsx
+++ b/src/components/ui/fluent/CategoryButton.tsx
@@ -14,7 +14,7 @@ interface BaseProps {
     readonly largeDescription?: boolean;
 }
 
-const CategoryBase = styled.div<BaseProps>`
+export const CategoryBase = styled.div<BaseProps>`
     padding: 9.8px 12px;
     border-radius: var(--border-radius);
     margin-bottom: 10px;

--- a/src/context/intermediate/Intermediate.tsx
+++ b/src/context/intermediate/Intermediate.tsx
@@ -16,6 +16,7 @@ import { internalSubscribe } from "../../lib/eventEmitter";
 import { determineLink } from "../../lib/links";
 
 import { useApplicationState } from "../../mobx/State";
+import { KeyCombo } from "../../mobx/stores/Keybinds";
 
 import { Action } from "../../components/ui/Modal";
 
@@ -109,6 +110,11 @@ export type Screen =
     | {
           id: "server_identity";
           server: Server;
+      }
+    | {
+          id: "keybind_capture";
+          actionName: string;
+          onSubmit: (keys: KeyCombo[]) => void;
       };
 
 export const IntermediateContext = createContext({

--- a/src/context/intermediate/Modals.tsx
+++ b/src/context/intermediate/Modals.tsx
@@ -5,11 +5,12 @@ import { isModalClosing } from "../../components/ui/Modal";
 import { Screen } from "./Intermediate";
 import { ClipboardModal } from "./modals/Clipboard";
 import { ErrorModal } from "./modals/Error";
+import { ExternalLinkModal } from "./modals/ExternalLinkPrompt";
 import { InputModal } from "./modals/Input";
+import { InputCaptureModal } from "./modals/InputCapture";
 import { OnboardingModal } from "./modals/Onboarding";
 import { PromptModal } from "./modals/Prompt";
 import { SignedOutModal } from "./modals/SignedOut";
-import {ExternalLinkModal} from "./modals/ExternalLinkPrompt";
 import { TokenRevealModal } from "./modals/TokenReveal";
 
 export interface Props {
@@ -40,6 +41,8 @@ export default function Modals({ screen, openScreen }: Props) {
             return <OnboardingModal onClose={onClose} {...screen} />;
         case "external_link_prompt":
             return <ExternalLinkModal onClose={onClose} {...screen} />;
+        case "keybind_capture":
+            return <InputCaptureModal onClose={onClose} {...screen} />;
     }
 
     return null;

--- a/src/context/intermediate/modals/InputCapture.tsx
+++ b/src/context/intermediate/modals/InputCapture.tsx
@@ -39,6 +39,7 @@ const InputBox = styled.output`
     font-family: var(--monospace-font);
     border-radius: var(--border-radius);
     background: var(--secondary-background);
+    height: 4ch;
 
     kbd {
         flex-wrap: wrap;
@@ -141,7 +142,7 @@ export const InputCaptureModal = ({ onClose, onSubmit, actionName }: Props) => {
                 <InputBox
                     tabIndex={0}
                     ref={input}
-                    onClick={reset}
+                    onFocus={reset}
                     onKeyDownCapture={onKeyDown}
                     onKeyUpCapture={onKeyUp}>
                     {sequence.length + mods.length > 0 ? (

--- a/src/context/intermediate/modals/InputCapture.tsx
+++ b/src/context/intermediate/modals/InputCapture.tsx
@@ -152,9 +152,7 @@ export const InputCaptureModal = ({ onClose, onSubmit, actionName }: Props) => {
                             )}
                         />
                     ) : (
-                        <Text id="app.special.modals.input_capture.placeholder">
-                            Press keys to record
-                        </Text>
+                        <Text id="app.special.modals.input_capture.placeholder" />
                     )}
                 </InputBox>
                 <IconButton title="clear input" onClick={reset}>

--- a/src/context/intermediate/modals/InputCapture.tsx
+++ b/src/context/intermediate/modals/InputCapture.tsx
@@ -1,0 +1,163 @@
+import { Reset } from "@styled-icons/boxicons-regular";
+import styled from "styled-components";
+
+import { createRef } from "preact";
+import { Text } from "preact-i18n";
+import { useEffect, useState } from "preact/hooks";
+
+import {
+    KEYBINDING_MODIFIER_KEYS,
+    KeyCombo,
+} from "../../../mobx/stores/Keybinds";
+
+import IconButton from "../../../components/ui/IconButton";
+import Modal from "../../../components/ui/Modal";
+
+import { Keybind } from "../../../pages/settings/panes/Keybinds";
+
+type Props = {
+    actionName: string;
+    onClose: () => void;
+    onSubmit: (keys: KeyCombo[]) => void;
+};
+
+const Container = styled.div`
+    display: flex;
+    gap: 1ch;
+    place-items: center;
+`;
+
+// taken from theme tools, it may be a good idea to eventually make a style for "boxes" like this
+const InputBox = styled.output`
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    font-size: 0.875rem;
+    min-width: 0;
+    flex-grow: 1;
+    padding: 8px;
+    font-family: var(--monospace-font);
+    border-radius: var(--border-radius);
+    background: var(--secondary-background);
+
+    kbd {
+        flex-wrap: wrap;
+    }
+`;
+
+const REPLACEMENTS: Record<string, string> = {
+    " ": "Space",
+};
+
+// some notes, could be considered bugs
+// if a key is held down and not resolved, ex. losing focus then the next key will override it.
+// if a combo is pressed like ctrl+a and ctrl is released while holding a for another second, a will be added to the sequence again.
+
+export const InputCaptureModal = ({ onClose, onSubmit, actionName }: Props) => {
+    const [sequence, setSequence] = useState<KeyCombo[]>([]);
+    const [mods, setMods] = useState<string[]>([]);
+    const okButton = createRef<HTMLButtonElement>();
+    const input = createRef<HTMLOutputElement>();
+    const timer = createRef<NodeJS.Timeout>();
+
+    const submit = () => {
+        if (sequence.length > 0) {
+            onSubmit(sequence);
+        }
+        onClose();
+    };
+
+    const reset = () => {
+        setSequence([]);
+        setMods([]);
+        input.current?.focus();
+    };
+
+    function onKeyDown(event: KeyboardEvent) {
+        event.preventDefault();
+
+        if (event.repeat) return;
+        timer.current && clearTimeout(timer.current);
+
+        const mods = KEYBINDING_MODIFIER_KEYS.filter((mod) =>
+            event.getModifierState(mod),
+        );
+        if (KEYBINDING_MODIFIER_KEYS.includes(event.key)) {
+            setMods(mods);
+        } else {
+            setMods([]);
+            setSequence((seq) => [
+                ...seq,
+                [...mods, REPLACEMENTS[event.key] ?? event.key],
+            ]);
+            if (sequence.length >= 1) {
+                okButton.current?.focus();
+            }
+        }
+    }
+
+    function onKeyUp(event: KeyboardEvent) {
+        event.preventDefault();
+
+        // Allow the user to use keyboard navigation again.
+        if (mods.length === 0) {
+            timer.current = setTimeout(() => {
+                okButton.current?.focus();
+            }, 1000);
+        }
+
+        if (mods.length > 0 && KEYBINDING_MODIFIER_KEYS.includes(event.key)) {
+            setSequence((seq) => [...seq, mods]);
+            setMods([]);
+            if (sequence.length >= 1) {
+                okButton.current?.focus();
+            }
+        }
+    }
+
+    useEffect(() => {
+        input.current?.focus();
+    }, []);
+
+    return (
+        <Modal
+            visible={true}
+            onClose={onClose}
+            title={`Keybinding for ${actionName}`}
+            actions={[
+                {
+                    ref: okButton,
+                    onClick: submit,
+                    confirmation: true,
+                    children: <Text id="app.special.modals.actions.ok" />,
+                },
+                {
+                    onClick: onClose,
+                    confirmation: false,
+                    children: <Text id="app.special.modals.actions.cancel" />,
+                },
+            ]}>
+            <Container>
+                <InputBox
+                    tabIndex={0}
+                    ref={input}
+                    onClick={reset}
+                    onKeyDownCapture={onKeyDown}
+                    onKeyUpCapture={onKeyUp}>
+                    {sequence.length + mods.length > 0 ? (
+                        <Keybind
+                            sequence={sequence.concat(
+                                mods.length > 0 ? [mods] : [],
+                            )}
+                        />
+                    ) : (
+                        "Press a key"
+                    )}
+                </InputBox>
+                <IconButton title="clear input" onClick={reset}>
+                    <Reset size={20} />
+                </IconButton>
+            </Container>
+        </Modal>
+    );
+};

--- a/src/context/intermediate/modals/InputCapture.tsx
+++ b/src/context/intermediate/modals/InputCapture.tsx
@@ -147,12 +147,14 @@ export const InputCaptureModal = ({ onClose, onSubmit, actionName }: Props) => {
                     onKeyUpCapture={onKeyUp}>
                     {sequence.length + mods.length > 0 ? (
                         <Keybind
-                            sequence={sequence.concat(
+                            children={sequence.concat(
                                 mods.length > 0 ? [mods] : [],
                             )}
                         />
                     ) : (
-                        "Press a key"
+                        <Text id="app.special.modals.input_capture.placeholder">
+                            Press keys to record
+                        </Text>
                     )}
                 </InputBox>
                 <IconButton title="clear input" onClick={reset}>

--- a/src/context/revoltjs/RevoltClient.tsx
+++ b/src/context/revoltjs/RevoltClient.tsx
@@ -86,7 +86,6 @@ export default observer(({ children }: Props) => {
 
     // register keybind listener
     useEffect(() => {
-        // const handler = state.keybinds.createHandler();
         document.addEventListener("keydown", state.keybinds);
         return () => document.addEventListener("keydown", state.keybinds);
     }, [state.keybinds]);

--- a/src/context/revoltjs/util.tsx
+++ b/src/context/revoltjs/util.tsx
@@ -1,4 +1,6 @@
+import { Client } from "revolt.js";
 import { Channel } from "revolt.js/dist/maps/Channels";
+import { Server } from "revolt.js/dist/maps/Servers";
 
 import { Text } from "preact-i18n";
 
@@ -46,4 +48,19 @@ export function getChannelName(
     }
 
     return <>{channel.name}</>;
+}
+
+// todo: please make a better way to do this
+// server.orderedChannels or something
+export function serverChannels(server: Server, client: Client) {
+    const ids = new Set(server.channel_ids);
+    return server?.categories
+        ?.flatMap((cat) =>
+            cat.channels.map((id) => {
+                ids.delete(id);
+                return client.channels.get(id);
+            }),
+        )
+        .concat(Array.from(ids, (id) => client.channels.get(id)))
+        .filter((ch) => ch !== undefined) as Channel[];
 }

--- a/src/context/revoltjs/util.tsx
+++ b/src/context/revoltjs/util.tsx
@@ -52,15 +52,15 @@ export function getChannelName(
 
 // todo: please make a better way to do this
 // server.orderedChannels or something
-export function serverChannels(server: Server, client: Client) {
+export function serverChannels(server: Server) {
     const ids = new Set(server.channel_ids);
     return server?.categories
         ?.flatMap((cat) =>
             cat.channels.map((id) => {
                 ids.delete(id);
-                return client.channels.get(id);
+                return server.client.channels.get(id);
             }),
         )
-        .concat(Array.from(ids, (id) => client.channels.get(id)))
+        .concat(Array.from(ids, (id) => server.client.channels.get(id)))
         .filter((ch) => ch !== undefined) as Channel[];
 }

--- a/src/lib/TextAreaAutoSize.tsx
+++ b/src/lib/TextAreaAutoSize.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-import { RefObject } from "preact";
+import { Ref, RefObject } from "preact";
 import { useEffect, useLayoutEffect, useRef } from "preact/hooks";
 
 import TextArea, { TextAreaProps } from "../components/ui/TextArea";
@@ -18,6 +18,7 @@ type TextAreaAutoSizeProps = Omit<
         minHeight?: number;
         maxRows?: number;
         value: string;
+        innerRef?: Ref<HTMLDivElement>;
 
         id?: string;
 
@@ -64,6 +65,7 @@ export default function TextAreaAutoSize(props: TextAreaAutoSizeProps) {
         hideBorder,
         forceFocus,
         onChange,
+        innerRef,
         ...textAreaProps
     } = props;
 
@@ -132,7 +134,7 @@ export default function TextAreaAutoSize(props: TextAreaAutoSizeProps) {
     }, [props.id, ref]);
 
     return (
-        <Container>
+        <Container ref={innerRef}>
             <TextArea
                 ref={ref}
                 value={value}

--- a/src/lib/debounce.ts
+++ b/src/lib/debounce.ts
@@ -2,75 +2,78 @@ import isEqual from "lodash.isequal";
 
 import { Inputs, useCallback, useEffect, useRef } from "preact/hooks";
 
-export function debounce(cb: (...args: unknown[]) => void, duration: number) {
-    // Store the timer variable.
-    let timer: NodeJS.Timeout;
-    // This function is given to React.
-    return (...args: unknown[]) => {
-        // Get rid of the old timer.
-        clearTimeout(timer);
-        // Set a new timer.
-        timer = setTimeout(() => {
-            // Instead calling the new function.
-            // (with the newer data)
-            cb(...args);
-        }, duration);
-    };
+export function debounce<T extends unknown[]>(
+  cb: (...args: T) => void,
+  duration: number,
+) {
+  // Store the timer variable.
+  let timer: NodeJS.Timeout;
+  // This function is given to React.
+  return (...args: T) => {
+    // Get rid of the old timer.
+    clearTimeout(timer);
+    // Set a new timer.
+    timer = setTimeout(() => {
+      // Instead calling the new function.
+      // (with the newer data)
+      cb(...args);
+    }, duration);
+  };
 }
 
-export function useDebounceCallback(
-    cb: (...args: unknown[]) => void,
-    inputs: Inputs,
-    duration = 1000,
+export function useDebounceCallback<T extends unknown[]>(
+  cb: (...args: T) => void,
+  inputs: Inputs,
+  duration = 1000,
 ) {
-    // eslint-disable-next-line
-    return useCallback(
-        debounce(cb as (...args: unknown[]) => void, duration),
-        inputs,
-    );
+  // eslint-disable-next-line
+  return useCallback(
+    debounce(cb, duration),
+    inputs,
+  );
 }
 
 export function useAutosaveCallback(
-    cb: (...args: unknown[]) => void,
-    inputs: Inputs,
-    duration = 1000,
+  cb: (...args: unknown[]) => void,
+  inputs: Inputs,
+  duration = 1000,
 ) {
-    const ref = useRef(cb);
+  const ref = useRef(cb);
 
+  // eslint-disable-next-line
+  const callback = useCallback(
+    debounce(() => ref.current(), duration),
+    [],
+  );
+
+  useEffect(() => {
+    ref.current = cb;
+    callback();
     // eslint-disable-next-line
-    const callback = useCallback(
-        debounce(() => ref.current(), duration),
-        [],
-    );
-
-    useEffect(() => {
-        ref.current = cb;
-        callback();
-        // eslint-disable-next-line
-    }, [cb, callback, ...inputs]);
+  }, [cb, callback, ...inputs]);
 }
 
 export function useAutosave<T>(
-    cb: () => void,
-    dependency: T,
-    initialValue: T,
-    onBeginChange?: () => void,
-    duration?: number,
+  cb: () => void,
+  dependency: T,
+  initialValue: T,
+  onBeginChange?: () => void,
+  duration?: number,
 ) {
-    if (onBeginChange) {
-        // eslint-disable-next-line
-        useEffect(
-            () => {
-                !isEqual(dependency, initialValue) && onBeginChange();
-            },
-            // eslint-disable-next-line
-            [dependency],
-        );
-    }
-
-    return useAutosaveCallback(
-        () => !isEqual(dependency, initialValue) && cb(),
-        [dependency],
-        duration,
+  if (onBeginChange) {
+    // eslint-disable-next-line
+    useEffect(
+      () => {
+        !isEqual(dependency, initialValue) && onBeginChange();
+      },
+      // eslint-disable-next-line
+      [dependency],
     );
+  }
+
+  return useAutosaveCallback(
+    () => !isEqual(dependency, initialValue) && cb(),
+    [dependency],
+    duration,
+  );
 }

--- a/src/lib/eventEmitter.ts
+++ b/src/lib/eventEmitter.ts
@@ -3,16 +3,16 @@ import EventEmitter from "eventemitter3";
 export const InternalEvent = new EventEmitter();
 
 export function internalSubscribe(
-    ns: string,
-    event: string,
-    fn: (...args: unknown[]) => void,
+  ns: string,
+  event: string,
+  fn: (...args: unknown[]) => void,
 ) {
-    InternalEvent.addListener(`${ns}/${event}`, fn);
-    return () => InternalEvent.removeListener(`${ns}/${event}`, fn);
+  InternalEvent.addListener(`${ns}/${event}`, fn);
+  return () => InternalEvent.removeListener(`${ns}/${event}`, fn);
 }
 
 export function internalEmit(ns: string, event: string, ...args: unknown[]) {
-    InternalEvent.emit(`${ns}/${event}`, ...args);
+  InternalEvent.emit(`${ns}/${event}`, ...args);
 }
 
 // Event structure: namespace/event
@@ -30,3 +30,5 @@ export function internalEmit(ns: string, event: string, ...args: unknown[]) {
 // - Modal/close
 // - PWA/update
 // - NewMessages/hide
+// - LeftSidebar/navigate_channels(direction: number)
+// - LeftSidebar/navigate_servers(direction: number)

--- a/src/mobx/State.ts
+++ b/src/mobx/State.ts
@@ -13,6 +13,7 @@ import Syncable from "./interfaces/Syncable";
 import Auth from "./stores/Auth";
 import Draft from "./stores/Draft";
 import Experiments from "./stores/Experiments";
+import Keybinds from "./stores/Keybinds";
 import Layout from "./stores/Layout";
 import LocaleOptions from "./stores/LocaleOptions";
 import MessageQueue from "./stores/MessageQueue";
@@ -39,6 +40,7 @@ export default class State {
     queue: MessageQueue;
     settings: Settings;
     sync: Sync;
+    keybinds: Keybinds;
 
     private persistent: [string, Persistent<unknown>][] = [];
     private disabled: Set<string> = new Set();
@@ -56,6 +58,7 @@ export default class State {
         this.notifications = new NotificationOptions();
         this.queue = new MessageQueue();
         this.settings = new Settings();
+        this.keybinds = new Keybinds();
         this.sync = new Sync(this);
 
         makeAutoObservable(this);

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -24,11 +24,17 @@ export enum KeybindAction {
     NavigateServerUp = "navigate_server_up",
     NavigateServerDown = "navigate_server_down",
 
+    NavigateAutoCompleteUp = "navigate_auto_complete_up",
+    NavigateAutoCompleteDown = "navigate_auto_complete_down",
+    AutoCompleteSelect = "auto_complete_select",
+
     NavigatePreviousContext = "navigate_previous_context",
     NavigatePreviousContextModal = "navigate_previous_context_modal",
     NavigatePreviousContextSettings = "navigate_previous_context_settings",
 
     InputSubmit = "input_submit",
+    InputCancel = "input_cancel",
+    InputForceSubmit = "input_force_submit",
 
     EditPreviousMessage = "edit_previous_message",
 }
@@ -118,10 +124,18 @@ export const DEFAULT_KEYBINDS = keybindMap({
     [KeybindAction.NavigateChannelDown]: ["Alt+ArrowDown"],
     [KeybindAction.NavigateServerUp]: ["Control+Alt+ArrowUp"],
     [KeybindAction.NavigateServerDown]: ["Control+Alt+ArrowDown"],
+
+    [KeybindAction.NavigateAutoCompleteUp]: ["ArrowUp"],
+    [KeybindAction.NavigateAutoCompleteDown]: ["ArrowDown"],
+    [KeybindAction.AutoCompleteSelect]: ["Enter", "Tab"],
+
     [KeybindAction.NavigatePreviousContext]: ["Escape"],
     [KeybindAction.NavigatePreviousContextModal]: [],
     [KeybindAction.NavigatePreviousContextSettings]: [],
+
+    [KeybindAction.InputForceSubmit]: ["Control+Enter"],
     [KeybindAction.InputSubmit]: ["Enter"],
+    [KeybindAction.InputCancel]: ["Escape"],
     [KeybindAction.EditPreviousMessage]: ["ArrowUp"],
 });
 

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -8,6 +8,7 @@ import {
     ObservableMap,
 } from "mobx";
 
+import { useText } from "preact-i18n";
 import { Inputs, useEffect } from "preact/hooks";
 
 import { debounce } from "../../lib/debounce";
@@ -19,10 +20,10 @@ import Store from "../interfaces/Store";
 // note: order dependent!
 export const KEYBINDING_MODIFIER_KEYS = ["Control", "Alt", "Meta", "Shift"];
 
-const DISPLAY_SHORT_REPLACEMENTS: Record<string, string> = {
-    Control: "Ctrl",
-    Escape: "Esc",
-};
+export const keyLong = (key: string) => useText(`keys.${key}.long`).long ?? key;
+
+export const keyShort = (key: string) =>
+    useText(`keys.${key}.short`).short ?? keyLong(key);
 
 export const KeyCombo = {
     fromKeyboardEvent(event: KeyboardEvent): KeyCombo {
@@ -42,7 +43,7 @@ export const KeyCombo = {
      * ex. replacing `Escape` with `Esc`
      */
     stringifyShort(combo: KeyCombo) {
-        return combo.map((k) => DISPLAY_SHORT_REPLACEMENTS[k] ?? k);
+        return combo.map(keyShort);
     },
 };
 
@@ -99,8 +100,8 @@ export enum KeybindAction {
     NavigateServerUp = "navigate_server_up",
     NavigateServerDown = "navigate_server_down",
 
-    NavigateAutoCompleteUp = "navigate_auto_complete_up",
-    NavigateAutoCompleteDown = "navigate_auto_complete_down",
+    AutoCompleteUp = "auto_complete_up",
+    AutoCompleteDown = "auto_complete_down",
     AutoCompleteSelect = "auto_complete_select",
 
     NavigatePreviousContext = "navigate_previous_context",
@@ -111,7 +112,7 @@ export enum KeybindAction {
     InputCancel = "input_cancel",
     InputForceSubmit = "input_force_submit",
 
-    MessagingHideNew = "messaging_hide_new",
+    MessagingMarkChannelRead = "messaging_mark_read",
     MessagingScrollToBottom = "messaging_scroll_to_bottom",
     MessagingEditPreviousMessage = "messaging_edit_previous_message",
 }
@@ -127,8 +128,8 @@ export const DEFAULT_KEYBINDS = keybindMap({
     [KeybindAction.NavigateServerUp]: ["Control+Alt+ArrowUp"],
     [KeybindAction.NavigateServerDown]: ["Control+Alt+ArrowDown"],
 
-    [KeybindAction.NavigateAutoCompleteUp]: ["ArrowUp"],
-    [KeybindAction.NavigateAutoCompleteDown]: ["ArrowDown"],
+    [KeybindAction.AutoCompleteUp]: ["ArrowUp"],
+    [KeybindAction.AutoCompleteDown]: ["ArrowDown"],
     [KeybindAction.AutoCompleteSelect]: ["Enter", "Tab"],
 
     [KeybindAction.NavigatePreviousContext]: ["Escape"],
@@ -139,7 +140,7 @@ export const DEFAULT_KEYBINDS = keybindMap({
     [KeybindAction.InputSubmit]: ["Enter"],
     [KeybindAction.InputCancel]: ["Escape"],
 
-    [KeybindAction.MessagingHideNew]: ["Escape"],
+    [KeybindAction.MessagingMarkChannelRead]: ["Escape"],
     [KeybindAction.MessagingScrollToBottom]: ["Escape"],
     [KeybindAction.MessagingEditPreviousMessage]: ["ArrowUp"],
 });

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -27,12 +27,12 @@ export const keyShort = (key: string) =>
 
 export const KeyCombo = {
     fromKeyboardEvent(event: KeyboardEvent): KeyCombo {
-        const pressed = KEYBINDING_MODIFIER_KEYS.filter(
-            (key) => event.getModifierState(key) && event.key,
+        const pressed = KEYBINDING_MODIFIER_KEYS.filter((key) =>
+            event.getModifierState(key),
         );
 
         if (!KEYBINDING_MODIFIER_KEYS.includes(event.key)) {
-            pressed.push(event.key);
+            pressed.push(event.key.replace(" ", "Space"));
         }
 
         return pressed;

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -111,7 +111,8 @@ export enum KeybindAction {
     InputCancel = "input_cancel",
     InputForceSubmit = "input_force_submit",
 
-    MessagingScrollToBottom = "scroll_to_bottom",
+    MessagingHideNew = "messaging_hide_new",
+    MessagingScrollToBottom = "messaging_scroll_to_bottom",
     MessagingEditPreviousMessage = "messaging_edit_previous_message",
 }
 
@@ -138,6 +139,7 @@ export const DEFAULT_KEYBINDS = keybindMap({
     [KeybindAction.InputSubmit]: ["Enter"],
     [KeybindAction.InputCancel]: ["Escape"],
 
+    [KeybindAction.MessagingHideNew]: ["Escape"],
     [KeybindAction.MessagingScrollToBottom]: ["Escape"],
     [KeybindAction.MessagingEditPreviousMessage]: ["ArrowUp"],
 });

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -16,29 +16,6 @@ import { internalEmit, internalSubscribe } from "../../lib/eventEmitter";
 import Persistent from "../interfaces/Persistent";
 import Store from "../interfaces/Store";
 
-/** Actions that keybinds can bind to */
-export enum KeybindAction {
-    // Navigation
-    NavigateChannelUp = "navigate_channel_up",
-    NavigateChannelDown = "navigate_channel_down",
-    NavigateServerUp = "navigate_server_up",
-    NavigateServerDown = "navigate_server_down",
-
-    NavigateAutoCompleteUp = "navigate_auto_complete_up",
-    NavigateAutoCompleteDown = "navigate_auto_complete_down",
-    AutoCompleteSelect = "auto_complete_select",
-
-    NavigatePreviousContext = "navigate_previous_context",
-    NavigatePreviousContextModal = "navigate_previous_context_modal",
-    NavigatePreviousContextSettings = "navigate_previous_context_settings",
-
-    InputSubmit = "input_submit",
-    InputCancel = "input_cancel",
-    InputForceSubmit = "input_force_submit",
-
-    EditPreviousMessage = "edit_previous_message",
-}
-
 // note: order dependent!
 export const KEYBINDING_MODIFIER_KEYS = ["Control", "Alt", "Meta", "Shift"];
 
@@ -114,6 +91,30 @@ function keybindMap(
     return new Map(parsed);
 }
 
+/** Actions that keybinds can bind to */
+export enum KeybindAction {
+    // Navigation
+    NavigateChannelUp = "navigate_channel_up",
+    NavigateChannelDown = "navigate_channel_down",
+    NavigateServerUp = "navigate_server_up",
+    NavigateServerDown = "navigate_server_down",
+
+    NavigateAutoCompleteUp = "navigate_auto_complete_up",
+    NavigateAutoCompleteDown = "navigate_auto_complete_down",
+    AutoCompleteSelect = "auto_complete_select",
+
+    NavigatePreviousContext = "navigate_previous_context",
+    NavigatePreviousContextModal = "navigate_previous_context_modal",
+    NavigatePreviousContextSettings = "navigate_previous_context_settings",
+
+    InputSubmit = "input_submit",
+    InputCancel = "input_cancel",
+    InputForceSubmit = "input_force_submit",
+
+    MessagingScrollToBottom = "scroll_to_bottom",
+    MessagingEditPreviousMessage = "messaging_edit_previous_message",
+}
+
 // If any are not defined here, things may break.
 /**
  * A map of the default built-in keybinds.
@@ -136,7 +137,9 @@ export const DEFAULT_KEYBINDS = keybindMap({
     [KeybindAction.InputForceSubmit]: ["Control+Enter"],
     [KeybindAction.InputSubmit]: ["Enter"],
     [KeybindAction.InputCancel]: ["Escape"],
-    [KeybindAction.EditPreviousMessage]: ["ArrowUp"],
+
+    [KeybindAction.MessagingScrollToBottom]: ["Escape"],
+    [KeybindAction.MessagingEditPreviousMessage]: ["ArrowUp"],
 });
 
 // naming:

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -20,10 +20,10 @@ import Store from "../interfaces/Store";
 // note: order dependent!
 export const KEYBINDING_MODIFIER_KEYS = ["Control", "Alt", "Meta", "Shift"];
 
-export const keyLong = (key: string) => useText(`keys.${key}.long`).long ?? key;
+export const keyFull = (key: string) => useText(`keys.${key}.full`).full ?? key;
 
 export const keyShort = (key: string) =>
-    useText(`keys.${key}.short`).short ?? keyLong(key);
+    useText(`keys.${key}.short`).short ?? keyFull(key);
 
 export const KeyCombo = {
     fromKeyboardEvent(event: KeyboardEvent): KeyCombo {
@@ -45,6 +45,10 @@ export const KeyCombo = {
     stringifyShort(combo: KeyCombo) {
         return combo.map(keyShort);
     },
+
+    stringifyFull(combo: KeyCombo) {
+        return combo.map(keyFull);
+    },
 };
 
 export const KeybindSequence = {
@@ -64,6 +68,13 @@ export const KeybindSequence = {
     /** Stringify a keybind sequence */
     stringify(sequence: KeyCombo[]) {
         return sequence.map((combo) => combo.join("+")).join(" ");
+    },
+
+    /** Stringify a keybind sequence */
+    stringifyFull(sequence: KeyCombo[]) {
+        return sequence
+            .map((combo) => KeyCombo.stringifyFull(combo).join("+"))
+            .join(" ");
     },
 
     /**
@@ -112,7 +123,7 @@ export enum KeybindAction {
     InputCancel = "input_cancel",
     InputForceSubmit = "input_force_submit",
 
-    MessagingMarkChannelRead = "messaging_mark_read",
+    MessagingMarkChannelRead = "messaging_mark_channel_read",
     MessagingScrollToBottom = "messaging_scroll_to_bottom",
     MessagingEditPreviousMessage = "messaging_edit_previous_message",
 }

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -1,0 +1,154 @@
+import {
+    action,
+    computed,
+    makeAutoObservable,
+    observable,
+    ObservableMap,
+} from "mobx";
+
+import { Inputs, useEffect } from "preact/hooks";
+
+import { internalSubscribe } from "../../lib/eventEmitter";
+
+import Persistent from "../interfaces/Persistent";
+import Store from "../interfaces/Store";
+
+/** Actions that keybinds can bind to */
+export enum Keybinding {
+    // Navigation
+    NavigateChannelUp = "navigate_channel_up",
+    NavigateChannelDown = "navigate_channel_down",
+    NavigateServerUp = "navigate_server_up",
+    NavigateServerDown = "navigate_server_down",
+}
+
+/**
+ * A map of the default built-in keybinds.
+ * every action must be represented.
+ */
+export const DEFAULT_KEYBINDS = new Map([
+    [Keybinding.NavigateChannelUp, ["Alt+ArrowUp"]],
+    [Keybinding.NavigateChannelDown, ["Alt+ArrowDown"]],
+    [Keybinding.NavigateServerUp, ["Ctrl+Alt+ArrowUp"]],
+    [Keybinding.NavigateServerDown, ["Ctrl+Alt+ArrowDown"]],
+]);
+
+export interface Data {
+    keybinds: Record<Keybinding, string[]>;
+}
+
+/**
+ * Handles adding, remove, and fetching keybinds.
+ */
+export default class Keybinds implements Store, Persistent<Data> {
+    keybinds: ObservableMap<Keybinding, string[]>;
+
+    /**
+     * Construct new Keybinds store.
+     */
+    constructor() {
+        // If any are not defined here, things will break.
+        this.keybinds = observable.map(DEFAULT_KEYBINDS);
+        makeAutoObservable(this);
+    }
+
+    get id() {
+        return "keybinds";
+    }
+
+    /** Get the default built-in keybind of an action */
+    getDefault(action: Keybinding, index: number) {
+        return DEFAULT_KEYBINDS.get(action)?.[index];
+    }
+
+    // disableAction action
+    // disables an active keybind from without removing it
+    // useful for the keybindings setting where disabling all keybinds may be a good idea
+
+    // enableAction action
+    // enables a disabled keybind
+
+    // useAction action, fn, inputs
+    // listen to an actions events
+
+    toJSON() {
+        return {
+            keybinds: this.keybinds.toJSON(),
+        };
+    }
+
+    @action
+    hydrate(data: Data) {
+        this.keybinds.merge(data.keybinds);
+    }
+
+    /**
+     * Get a list of keybind expressions for a given action.
+     * @param action The action to get the keybinds for
+     */
+    @computed
+    getKeybinds(action: Keybinding) {
+        return this.keybinds.get(action)!;
+    }
+
+    @action
+    setKeybind(action: Keybinding, index: number, sequence: string) {
+        this.keybinds.get(action)![index] = sequence;
+    }
+
+    @action
+    addKeybind(action: Keybinding, sequence: string) {
+        this.keybinds.get(action)!.push(sequence);
+    }
+
+    /**
+     * Resets a keybind back to the built-in default.
+     * If there is none, remove it from the list of keybinds for the given action.
+     */
+    @action
+    resetToDefault(action: Keybinding, index: number) {
+        const keybinds = this.keybinds.get(action)!;
+        const defaultValue = this.getDefault(action, index);
+        if (defaultValue) {
+            keybinds[index] = defaultValue;
+        } else {
+            keybinds.splice(index, 1);
+        }
+    }
+
+    /** Reset and set all keybinds back to default. */
+    @action
+    reset() {
+        this.keybinds.replace(DEFAULT_KEYBINDS);
+    }
+}
+
+// naming:
+// modifiers + key is a combo
+// a sequence of combos is a sequence (also called a keybind)
+
+/**
+ * Keys that must be pressed at the same time, order should not matter.
+ * Should only be include modifiers and one key at the moment.
+ */
+export type KeyCombo = string[];
+
+export const KeybindSequence = {
+    /**
+     * Parse a stringified keybind seqeuence.
+     *
+     * @example
+     * ```
+     * parse('Alt+ArrowUp')
+     * parse('Control+k b')
+     * ```
+     */
+    parse(sequence: string) {
+        return sequence.split(" ").map((expr) => expr.split("+"));
+    },
+
+    /** Stringify a keybind sequence */
+    stringify(sequence: KeyCombo[]) {
+        return sequence.map((combo) => combo.join("+")).join(" ");
+    },
+};

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -70,6 +70,7 @@ export const KeybindSequence = {
         return sequence.map((combo) => combo.join("+")).join(" ");
     },
 
+    // todo: better names
     /** Stringify a keybind sequence */
     stringifyFull(sequence: KeyCombo[]) {
         return sequence

--- a/src/mobx/stores/Keybinds.ts
+++ b/src/mobx/stores/Keybinds.ts
@@ -1,4 +1,3 @@
-import EventEmitter from "eventemitter3";
 import isEqual from "lodash.isequal";
 import {
     action,
@@ -7,7 +6,6 @@ import {
     makeAutoObservable,
     observable,
     ObservableMap,
-    ObservableSet,
 } from "mobx";
 
 import { Inputs, useEffect } from "preact/hooks";
@@ -35,6 +33,7 @@ export enum KeybindAction {
     EditPreviousMessage = "edit_previous_message",
 }
 
+// If any are not defined here, things may break.
 /**
  * A map of the default built-in keybinds.
  * every action must be represented.
@@ -75,15 +74,9 @@ export type Keybinding = {
 };
 
 export interface Data {
-    // note: data is stored in string format but parsed on load
     keybinds: Record<KeybindAction, Keybinding>;
 }
 
-class KeybindEvent extends KeyboardEvent {
-    constructor(type: string, event: KeyboardEvent) {
-        super(type, event);
-    }
-}
 /**
  * Handles adding, remove, and fetching keybinds.
  */
@@ -136,7 +129,6 @@ export default class Keybinds implements Store, Persistent<Data> {
      * Construct new Keybinds store.
      */
     constructor() {
-        // If any are not defined here, things will break.
         this.keybinds = observable.map(DEFAULT_KEYBINDS);
         makeAutoObservable(this);
     }
@@ -167,7 +159,6 @@ export default class Keybinds implements Store, Persistent<Data> {
             [index].sequence.map(KeyCombo.stringifyShort);
     }
 
-    // todo: better name
     @computed
     getKeybindList() {
         return entries(this.keybinds).flatMap(([action, keybinds]) =>
@@ -175,6 +166,8 @@ export default class Keybinds implements Store, Persistent<Data> {
         );
     }
 
+    // todo: store keybinds through their stringified representation
+    // todo: only save modified keybinds
     toJSON() {
         return {
             keybinds: this.keybinds.toJSON(),

--- a/src/pages/channels/messaging/MessageArea.tsx
+++ b/src/pages/channels/messaging/MessageArea.tsx
@@ -21,6 +21,9 @@ import { internalEmit, internalSubscribe } from "../../../lib/eventEmitter";
 import { getRenderer } from "../../../lib/renderer/Singleton";
 import { ScrollState } from "../../../lib/renderer/types";
 
+import { useApplicationState } from "../../../mobx/State";
+import { KeybindAction } from "../../../mobx/stores/Keybinds";
+
 import { IntermediateContext } from "../../../context/intermediate/Intermediate";
 import RequiresOnline from "../../../context/revoltjs/RequiresOnline";
 import {
@@ -64,6 +67,7 @@ export const MessageAreaWidthContext = createContext(0);
 export const MESSAGE_AREA_PADDING = 82;
 
 export const MessageArea = observer(({ last_id, channel }: Props) => {
+    const keybinds = useApplicationState().keybinds;
     const history = useHistory();
     const status = useContext(StatusContext);
     const { focusTaken } = useContext(IntermediateContext);
@@ -304,17 +308,16 @@ export const MessageArea = observer(({ last_id, channel }: Props) => {
     }, [ref, scrollState, stbOnResize]);
 
     // ? Scroll to bottom when pressing 'Escape'.
-    useEffect(() => {
-        function keyUp(e: KeyboardEvent) {
-            if (e.key === "Escape" && !focusTaken) {
+    keybinds.useAction(
+        KeybindAction.MessagingScrollToBottom,
+        (e) => {
+            if (!e.defaultPrevented && !focusTaken) {
                 renderer.jumpToBottom(true);
                 internalEmit("TextArea", "focus", "message");
             }
-        }
-
-        document.body.addEventListener("keyup", keyUp);
-        return () => document.body.removeEventListener("keyup", keyUp);
-    }, [renderer, ref, focusTaken]);
+        },
+        [renderer, ref, focusTaken],
+    );
 
     return (
         <MessageAreaWidthContext.Provider

--- a/src/pages/channels/messaging/MessageEditor.tsx
+++ b/src/pages/channels/messaging/MessageEditor.tsx
@@ -104,6 +104,11 @@ export default function MessageEditor({ message, finish }: Props) {
         [textAreaRef],
     );
 
+    keybinds.useAction(KeybindAction.InputForceSubmit, (e) => {
+        e.preventDefault();
+        save();
+    });
+
     const inputCancel = keybinds.getKeybinds(KeybindAction.InputCancel)[0]
         .sequence;
 

--- a/src/pages/channels/messaging/MessageEditor.tsx
+++ b/src/pages/channels/messaging/MessageEditor.tsx
@@ -109,12 +109,6 @@ export default function MessageEditor({ message, finish }: Props) {
         save();
     });
 
-    const inputCancel = keybinds.getKeybinds(KeybindAction.InputCancel)[0]
-        .sequence;
-
-    const inputSubmit = keybinds.getKeybinds(KeybindAction.InputSubmit)[0]
-        .sequence;
-
     const { onChange, onKeyUp, onFocus, onBlur, ...autoCompleteProps } =
         useAutoComplete((v) => setContent(v ?? ""), {
             users: { type: "channel", id: message.channel!._id },
@@ -143,9 +137,10 @@ export default function MessageEditor({ message, finish }: Props) {
                 onBlur={onBlur}
             />
             <span className="caption">
-                <Keybind children={inputCancel} /> to{" "}
+                <Keybind action={KeybindAction.InputCancel} /> to{" "}
                 <a onClick={finish}>cancel</a> &middot;{" "}
-                <Keybind children={inputSubmit} /> to <a onClick={save}>save</a>
+                <Keybind action={KeybindAction.InputSubmit} /> to{" "}
+                <a onClick={save}>save</a>
             </span>
         </EditorBase>
     );

--- a/src/pages/channels/messaging/MessageEditor.tsx
+++ b/src/pages/channels/messaging/MessageEditor.tsx
@@ -75,7 +75,12 @@ export default function MessageEditor({ message, finish }: Props) {
     // ? Stop editing when pressing ESC.
     keybinds.useAction(
         KeybindAction.InputCancel,
-        (e) => !focusTaken && finish(),
+        (e) => {
+            if (!focusTaken) {
+                e.preventDefault();
+                finish();
+            }
+        },
         [focusTaken, finish],
     );
 

--- a/src/pages/settings/GenericSettings.tsx
+++ b/src/pages/settings/GenericSettings.tsx
@@ -6,16 +6,12 @@ import styles from "./Settings.module.scss";
 import classNames from "classnames";
 import { createRef } from "preact";
 import { Text } from "preact-i18n";
-import { useCallback, useMemo, useRef, useState } from "preact/hooks";
+import { useCallback, useRef, useState } from "preact/hooks";
 
 import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
 
 import { useApplicationState } from "../../mobx/State";
-import {
-    KeybindAction,
-    KeybindSequence,
-    KeyCombo,
-} from "../../mobx/stores/Keybinds";
+import { KeybindAction } from "../../mobx/stores/Keybinds";
 
 import Category from "../../components/ui/Category";
 import Header from "../../components/ui/Header";
@@ -24,6 +20,7 @@ import LineDivider from "../../components/ui/LineDivider";
 
 import ButtonItem from "../../components/navigation/items/ButtonItem";
 import { Children } from "../../types/Preact";
+import { Keybind } from "./panes/Keybinds";
 
 interface Props {
     pages: {
@@ -196,20 +193,20 @@ export function GenericSettings({
                             {children}
                         </div>
                         {!isTouchscreenDevice && (
-                            <div
-                                className={styles.action}
-                                style={{
-                                    // note: doesn't update reactively.
-                                    "--key-esc": `"${keybinds.withLocalization(
-                                        KeybindAction.NavigatePreviousContext,
-                                        0,
-                                        { short: true },
-                                    )}"`,
-                                }}>
-                                <div
-                                    onClick={exitSettings}
-                                    className={styles.closeButton}>
-                                    <X size={28} />
+                            <div className={styles.action}>
+                                <div className={styles.close}>
+                                    <IconButton
+                                        onClick={exitSettings}
+                                        className={styles.closeButton}>
+                                        <X size={28} />
+                                    </IconButton>
+                                    <Keybind
+                                        className={styles.keybind}
+                                        action={
+                                            KeybindAction.NavigatePreviousContext
+                                        }
+                                        short
+                                    />
                                 </div>
                             </div>
                         )}

--- a/src/pages/settings/GenericSettings.tsx
+++ b/src/pages/settings/GenericSettings.tsx
@@ -81,17 +81,6 @@ export function GenericSettings({
         [exitSettings],
     );
 
-    // useMemo isn't really doing anything here.
-    const exitKeybind = useMemo(
-        () =>
-            KeybindSequence.stringifyFull(
-                state.keybinds
-                    .getKeybinds(KeybindAction.NavigatePreviousContext)[0]
-                    .sequence.map(KeyCombo.stringifyShort),
-            ),
-        [keybinds.keybinds],
-    );
-
     const pageRef = useRef<string>();
 
     return (
@@ -211,7 +200,11 @@ export function GenericSettings({
                                 className={styles.action}
                                 style={{
                                     // note: doesn't update reactively.
-                                    "--key-esc": `"${exitKeybind}"`,
+                                    "--key-esc": `"${keybinds.withLocalization(
+                                        KeybindAction.NavigatePreviousContext,
+                                        0,
+                                        { short: true },
+                                    )}"`,
                                 }}>
                                 <div
                                     onClick={exitSettings}

--- a/src/pages/settings/GenericSettings.tsx
+++ b/src/pages/settings/GenericSettings.tsx
@@ -84,7 +84,7 @@ export function GenericSettings({
     // useMemo isn't really doing anything here.
     const exitKeybind = useMemo(
         () =>
-            KeybindSequence.stringify(
+            KeybindSequence.stringifyFull(
                 state.keybinds
                     .getKeybinds(KeybindAction.NavigatePreviousContext)[0]
                     .sequence.map(KeyCombo.stringifyShort),

--- a/src/pages/settings/GenericSettings.tsx
+++ b/src/pages/settings/GenericSettings.tsx
@@ -77,10 +77,7 @@ export function GenericSettings({
 
     keybinds.useAction(
         KeybindAction.NavigatePreviousContextSettings,
-        (e) => {
-            console.log("Settings");
-            exitSettings();
-        },
+        (e) => exitSettings(),
         [exitSettings],
     );
 

--- a/src/pages/settings/Settings.module.scss
+++ b/src/pages/settings/Settings.module.scss
@@ -278,35 +278,38 @@
         position: sticky;
         top: 0;
 
-        &:after {
-            content: var(--key-esc, "Esc");
-            margin-top: 4px;
-            display: flex;
-            justify-content: center;
-            width: 40px;
-            opacity: 0.5;
-            font-size: 0.75rem;
-            text-transform: uppercase;
-        }
+        display: flex;
+        place-items: start;
 
-        .closeButton {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: var(--border-radius-half);
-            height: 40px;
-            width: 40px;
-            border: 3px solid var(--tertiary-background);
-            cursor: pointer;
+        .close {
+            display: grid;
+            place-items: center;
+            gap: 4px;
 
-            svg {
-                color: var(--secondary-foreground);
+            .keybind {
+                font-size: 0.65rem;
+                opacity: 0.5;
             }
-            &:hover {
-                background: var(--secondary-header);
-            }
-            &:active {
-                transform: translateY(2px);
+
+            .closeButton {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                border-radius: var(--border-radius-half);
+                height: 40px;
+                width: 40px;
+                border: 3px solid var(--tertiary-background);
+                cursor: pointer;
+
+                svg {
+                    color: var(--secondary-foreground);
+                }
+                &:hover {
+                    background: var(--secondary-header);
+                }
+                &:active {
+                    transform: translateY(2px);
+                }
             }
         }
     }

--- a/src/pages/settings/Settings.module.scss
+++ b/src/pages/settings/Settings.module.scss
@@ -279,13 +279,14 @@
         top: 0;
 
         &:after {
-            content: "ESC";
+            content: var(--key-esc, "Esc");
             margin-top: 4px;
             display: flex;
             justify-content: center;
             width: 40px;
             opacity: 0.5;
             font-size: 0.75rem;
+            text-transform: uppercase;
         }
 
         .closeButton {

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -4,6 +4,7 @@ import {
     Globe,
     LogOut,
     Desktop,
+    Key,
 } from "@styled-icons/boxicons-regular";
 import {
     Bell,
@@ -18,6 +19,7 @@ import {
     Store,
     Bot,
     Trash,
+    Keyboard,
 } from "@styled-icons/boxicons-solid";
 import { observer } from "mobx-react-lite";
 import { Route, Switch, useHistory } from "react-router-dom";
@@ -49,6 +51,7 @@ import { Appearance } from "./panes/Appearance";
 import { Audio } from "./panes/Audio";
 import { ExperimentsPage } from "./panes/Experiments";
 import { Feedback } from "./panes/Feedback";
+import { Keybinds } from "./panes/Keybinds";
 import { Languages } from "./panes/Languages";
 import { MyBots } from "./panes/MyBots";
 import { Native } from "./panes/Native";
@@ -169,6 +172,12 @@ export default observer(() => {
                     title: <Text id="app.settings.pages.notifications.title" />,
                 },
                 {
+                    id: "keybinds",
+                    icon: <Keyboard size={20} />,
+                    // TODO: translate
+                    title: "Keybinds",
+                },
+                {
                     id: "language",
                     icon: <Globe size={20} />,
                     title: <Text id="app.settings.pages.language.title" />,
@@ -227,6 +236,9 @@ export default observer(() => {
                     </Route>
                     <Route path="/settings/notifications">
                         <Notifications />
+                    </Route>
+                    <Route path="/settings/keybinds">
+                        <Keybinds />
                     </Route>
                     <Route path="/settings/language">
                         <Languages />

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -29,7 +29,6 @@ import { useIntermediate } from "../../../context/intermediate/Intermediate";
 
 import CollapsibleSection from "../../../components/common/CollapsibleSection";
 import Tooltip from "../../../components/common/Tooltip";
-import Category from "../../../components/ui/Category";
 import IconButton from "../../../components/ui/IconButton";
 import InputBox from "../../../components/ui/InputBox";
 import CategoryButton from "../../../components/ui/fluent/CategoryButton";
@@ -332,7 +331,11 @@ export const GenericKeybinds = observer(
                     <CollapsibleSection
                         id={`keybinds_${categoryId}`}
                         defaultValue={categoryId !== "advanced"}
-                        summary={<Category text={categoryId} />}>
+                        summary={
+                            <Text
+                                id={`app.settings.pages.keybinds.category.${categoryId}`}
+                            />
+                        }>
                         <KeybindSection
                             id={categoryId}
                             actions={actions}

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -319,7 +319,7 @@ export const Keybinds = observer(() => {
                     },
                     messaging: {
                         edit_previous_message:
-                            KeybindAction.EditPreviousMessage,
+                            KeybindAction.MessagingEditPreviousMessage,
                     },
                 }}
             />

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -46,12 +46,12 @@ const REPLACEMENTS: Record<string, () => JSX.Element> = {
 type KeyProps = {
     children: string;
     short?: boolean;
-    simple?: boolean;
+    pressable?: boolean;
 };
 const Key = styled.kbd.attrs<KeyProps, { light: boolean }>(
-    ({ children: key, short = true, simple = false }) => {
+    ({ children: key, short = true, pressable = false }) => {
         return {
-            simple,
+            pressable,
             children:
                 REPLACEMENTS[key]?.() ?? (short ? keyShort(key) : keyFull(key)),
             light: useApplicationState().settings.theme.isLight(),
@@ -80,7 +80,7 @@ const Key = styled.kbd.attrs<KeyProps, { light: boolean }>(
     }
 
     ${(props) =>
-        !props.simple &&
+        props.pressable &&
         css`
             box-shadow: 0 1px 1px rgba(133, 133, 133, 0.2),
                 0 2.5px 0 0 rgba(0, 0, 0, 0.5);
@@ -104,7 +104,6 @@ const KeySequence = styled.kbd`
     font-size: 0.85em;
     font-family: var(--monospace-font), monospace;
 
-    // todo: clean this up
     & > kbd {
         display: inline-flex;
         align-items: center;
@@ -116,12 +115,12 @@ const KeySequence = styled.kbd`
 type KeybindProps = {
     children: string | KeyCombo[];
     short?: boolean;
-    simple?: boolean;
+    pressable?: boolean;
 };
 export const Keybind = ({
     children: sequence,
     short,
-    simple,
+    pressable,
 }: KeybindProps) => {
     const keys =
         typeof sequence === "string"
@@ -135,7 +134,7 @@ export const Keybind = ({
                 <Key
                     children={mod}
                     short={short ?? keys.flat().length > 1}
-                    simple={simple}
+                    pressable={pressable}
                 />,
             ])}
         </kbd>
@@ -193,7 +192,7 @@ const KeybindEntries = observer(({ action }: KeybindEntriesProps) => {
 
         return (
             <div class="keybind">
-                <Keybind>{keybind.sequence}</Keybind>
+                <Keybind pressable>{keybind.sequence}</Keybind>
                 <Tooltip
                     content={
                         <Text id="app.settings.pages.keybinds.edit_keybind" />
@@ -225,7 +224,7 @@ const KeybindEntries = observer(({ action }: KeybindEntriesProps) => {
                                         id="app.settings.pages.keybinds.reset_keybind"
                                         fields={{
                                             keybind: (
-                                                <Keybind simple>
+                                                <Keybind>
                                                     {defaultSequence}
                                                 </Keybind>
                                             ),
@@ -368,7 +367,6 @@ export const Keybinds = observer(() => {
             KeybindAction.MessagingScrollToBottom,
             KeybindAction.MessagingMarkChannelRead,
 
-            // todo: localize as "Go back" or "Cancel"?
             // probably won't be displayed unless under an advanced section.
             KeybindAction.NavigatePreviousContext,
         ],
@@ -393,9 +391,13 @@ export const Keybinds = observer(() => {
                         ...keybinds
                             .getKeybinds(action)
                             .flatMap((keybind) => [
-                                KeybindSequence.stringifyFull(keybind.sequence),
-                                KeybindSequence.stringifyShort(
+                                KeybindSequence.withLocalization(
                                     keybind.sequence,
+                                    { short: true },
+                                ),
+                                KeybindSequence.withLocalization(
+                                    keybind.sequence,
+                                    { short: false },
                                 ),
                             ]),
                     ];

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -1,0 +1,327 @@
+import {
+    LeftArrowAlt,
+    DownArrowAlt,
+    RightArrowAlt,
+    UpArrowAlt,
+    Reset,
+} from "@styled-icons/boxicons-regular";
+import {
+    XCircle,
+    Edit,
+    PlusCircle,
+    Pencil,
+} from "@styled-icons/boxicons-solid";
+import isEqual from "lodash.isequal";
+import { observer } from "mobx-react-lite";
+import styled from "styled-components";
+
+import styles from "./Panes.module.scss";
+import { JSX } from "preact";
+import { Text } from "preact-i18n";
+
+import { useApplicationState } from "../../../mobx/State";
+import KeybindsType, {
+    KeybindAction,
+    Keybinding,
+    KeybindSequence,
+    KeyCombo,
+} from "../../../mobx/stores/Keybinds";
+
+import { useIntermediate } from "../../../context/intermediate/Intermediate";
+
+import CollapsibleSection from "../../../components/common/CollapsibleSection";
+import Categories from "../../../components/ui/Category";
+import IconButton from "../../../components/ui/IconButton";
+import CategoryButton, {
+    CategoryBase,
+} from "../../../components/ui/fluent/CategoryButton";
+
+const KeySequence = styled.kbd`
+    display: inline-flex;
+    place-items: center;
+    font-size: 1rem;
+    gap: 1ch;
+    line-height: 1;
+    flex-wrap: wrap;
+
+    // todo: clean this up
+    & > kbd {
+        display: inline-flex;
+        gap: 0.5ch;
+    }
+    & > kbd > kbd {
+        display: inline-flex;
+        background-color: var(--tertiary-background);
+
+        padding: 0.5ch 1ch 0.35ch;
+        border-radius: 3px;
+
+        outline: 1px solid rgb(66 66 66 / 0.5);
+        box-shadow: 0 1px 1px rgba(133, 133, 133, 0.2),
+            0 2.5px 0 0 rgba(0, 0, 0, 0.5);
+
+        font-size: 0.85em;
+        font-weight: 700;
+
+        text-transform: uppercase;
+
+        &:active {
+            outline: 1px solid rgb(0 0 0 / 0.3);
+            color: var(--tertiary-foreground);
+            transform: translateY(2px);
+            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+        }
+    }
+
+    svg {
+        // change arrow scaling in svgs to better fit the text
+        transform: scale(1.5);
+    }
+`;
+
+const REPLACEMENTS: Record<string, () => JSX.Element> = {
+    ArrowUp: () => <UpArrowAlt size="1em" />,
+    ArrowDown: () => <DownArrowAlt size="1em" />,
+    ArrowLeft: () => <LeftArrowAlt size="1em" />,
+    ArrowRight: () => <RightArrowAlt size="1em" />,
+};
+
+// todo: make this look cleaner
+const Key = ({ value: key }: { value: string }) => (
+    <kbd>{REPLACEMENTS[key]?.() ?? key}</kbd>
+);
+
+type KeybindProps = {
+    sequence: string | KeyCombo[];
+};
+export const Keybind = ({ sequence }: KeybindProps) => {
+    const keys = (
+        typeof sequence === "string"
+            ? KeybindSequence.parse(sequence)
+            : sequence
+    ).map((keybinding) => (
+        <kbd>
+            {KeyCombo.stringifyShort(keybinding).map((mod, i) => [
+                i > 0 ? "+" : null,
+                <Key value={mod} />,
+            ])}
+        </kbd>
+    ));
+
+    return <KeySequence>{keys}</KeySequence>;
+};
+
+// todo: use `main` in the future for better accessability
+const Container = styled.div`
+    // hack: increase specificity because Panes.module.css usually has higher.
+    &&& {
+        h1,
+        h2,
+        h3,
+        h4,
+        h5 {
+            text-transform: uppercase;
+            margin: 0;
+        }
+
+        header {
+            display: flex;
+            place-items: center;
+
+            label {
+                margin: 0;
+            }
+        }
+
+        .subsection {
+            display: flex;
+            flex-direction: column;
+            gap: 1ch;
+
+            hr {
+                margin: 0;
+            }
+        }
+
+        .action {
+            display: grid;
+            grid-template-columns: 1fr;
+            align-items: center;
+            // gap: 1ch 0.5ch;
+
+            .keybind {
+                display: flex;
+                place-items: center;
+                gap: 1ch;
+
+                padding: 9.8px 12px;
+
+                > kbd {
+                    flex: 1;
+                }
+            }
+
+            .unset-keybind {
+            }
+        }
+    }
+`;
+
+type Actions = Record<string, KeybindAction>;
+type Categories = Record<string, Actions>;
+
+type ActionProps = {
+    id: string;
+    action: KeybindAction;
+    keybinds: KeybindsType;
+};
+
+const ActionGroup = observer(({ id, action, keybinds }: ActionProps) => {
+    const { openScreen } = useIntermediate();
+
+    // todo: add category button sections support for each keybinding, similar to https://autumn.revolt.chat/attachments/6adrbbW9VwkLnnkL76MTX_nDrbp5LwVRKHBeVEN3-D is sectioned
+    return (
+        <article class="action">
+            <CategoryButton
+                onClick={() =>
+                    openScreen({
+                        id: "keybind_capture",
+                        actionName: id,
+                        onSubmit: (seq) =>
+                            keybinds.addKeybind(
+                                action,
+                                KeybindSequence.stringify(seq),
+                            ),
+                    })
+                }
+                action={<PlusCircle size={20} />}
+                description="navigate between channels in the current server">
+                {/* todo: localize */}
+                {id.toUpperCase()}
+            </CategoryButton>
+            {keybinds.getKeybinds(action).map((keybind, i) => {
+                const defaultSequence = keybinds.getDefault(action, i);
+                return (
+                    <div class="keybind">
+                        <Keybind sequence={keybind.sequence} />
+                        {/* TODO: tooltip this */}
+                        <IconButton
+                            onClick={() =>
+                                openScreen({
+                                    id: "keybind_capture",
+                                    actionName: id,
+                                    onSubmit: (seq) =>
+                                        keybinds.setKeybind(
+                                            action,
+                                            i,
+                                            KeybindSequence.stringify(seq),
+                                        ),
+                                })
+                            }>
+                            <Pencil size={20} />
+                        </IconButton>
+                        {!isEqual(
+                            keybind.sequence,
+                            defaultSequence?.sequence,
+                        ) && (
+                            <IconButton
+                                onClick={() =>
+                                    keybinds.resetToDefault(action, i)
+                                }>
+                                {/* TODO: tooltip these */}
+                                {defaultSequence ? (
+                                    <Reset
+                                        size={20}
+                                        title={`Reset to ${KeybindSequence.stringifyShort(
+                                            defaultSequence.sequence,
+                                        )}`}
+                                    />
+                                ) : (
+                                    <XCircle size={20} title="Remove" />
+                                )}
+                            </IconButton>
+                        )}
+                    </div>
+                );
+            })}
+        </article>
+    );
+});
+
+type SectionProps = {
+    id: string;
+    actions: Actions;
+    keybinds: KeybindsType;
+};
+
+const KeybindSection = observer(({ id, actions, keybinds }: SectionProps) => (
+    <section class="subsection">
+        {Array.from(Object.keys(actions), (actionName, i) => (
+            <>
+                {/* Technically `hr` shouldn't be used because of it's semantic meaning, but the rest of the app uses it so for consistency it's being used it here. */}
+                {i > 0 && <hr />}
+                <ActionGroup
+                    id={actionName}
+                    action={actions[actionName]}
+                    keybinds={keybinds}
+                />
+            </>
+        ))}
+    </section>
+));
+
+type GenericKeybindsProps = {
+    categories: Categories;
+    keybinds: KeybindsType;
+};
+
+export const GenericKeybinds = observer(
+    ({ categories, keybinds }: GenericKeybindsProps) => (
+        <>
+            {Array.from(Object.keys(categories), (categoryId) => {
+                const actions = categories[categoryId];
+                return (
+                    <CollapsibleSection
+                        id={`keybinds_${categoryId}`}
+                        defaultValue
+                        summary={<Categories text={categoryId} />}>
+                        <KeybindSection
+                            id={categoryId}
+                            actions={actions}
+                            keybinds={keybinds}
+                        />
+                    </CollapsibleSection>
+                );
+            })}
+        </>
+    ),
+);
+
+export const Keybinds = observer(() => {
+    const keybinds = useApplicationState().keybinds;
+    return (
+        <Container>
+            <GenericKeybinds
+                keybinds={keybinds}
+                categories={{
+                    navigation: {
+                        navigate_channels_up: KeybindAction.NavigateChannelUp,
+                        navigate_channels_down:
+                            KeybindAction.NavigateChannelDown,
+                        navigate_servers_up: KeybindAction.NavigateServerUp,
+                        navigate_servers_down: KeybindAction.NavigateServerDown,
+
+                        // todo: localize as "Go back" or "Cancel"?
+                        // probably won't be displayed unless under an advanced section.
+                        navigate_previous_context:
+                            KeybindAction.NavigatePreviousContext,
+                    },
+                    messaging: {
+                        edit_previous_message:
+                            KeybindAction.EditPreviousMessage,
+                    },
+                }}
+            />
+        </Container>
+    );
+});

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -105,6 +105,7 @@ const KeySequence = styled.kbd`
     display: inline-flex;
     place-items: center;
     flex-wrap: wrap;
+    gap: 1ch;
 
     line-height: 1;
     font-size: 0.85em;

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -160,9 +160,6 @@ const Container = styled.div`
                     flex: 1;
                 }
             }
-
-            .unset-keybind {
-            }
         }
     }
 `;
@@ -301,6 +298,10 @@ export const Keybinds = observer(() => {
     const keybinds = useApplicationState().keybinds;
     return (
         <Container>
+            {/* temporary */}
+            <IconButton onClick={() => keybinds.reset()}>
+                <Reset size={20} title={`Reset all keybinds`} />
+            </IconButton>
             <GenericKeybinds
                 keybinds={keybinds}
                 categories={{

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -36,7 +36,7 @@ import CategoryButton, {
     CategoryBase,
 } from "../../../components/ui/fluent/CategoryButton";
 
-const KeySequence = styled.kbd`
+const KeySequence = styled.kbd<{ light: boolean }>`
     display: inline-flex;
     place-items: center;
     font-size: 1rem;
@@ -51,7 +51,10 @@ const KeySequence = styled.kbd`
     }
     & > kbd > kbd {
         display: inline-flex;
-        background-color: var(--tertiary-background);
+        background-color: ${(props) =>
+            props.light
+                ? "rgb(var(--tertiary-background-rgb), 0.05)"
+                : "var(--tertiary-background)"};
 
         padding: 0.5ch 1ch 0.35ch;
         border-radius: 3px;
@@ -108,7 +111,9 @@ export const Keybind = ({ sequence }: KeybindProps) => {
         </kbd>
     ));
 
-    return <KeySequence>{keys}</KeySequence>;
+    const isLight = useApplicationState().settings.theme.isLight();
+
+    return <KeySequence light={isLight}>{keys}</KeySequence>;
 };
 
 // todo: use `main` in the future for better accessability

--- a/src/pages/settings/panes/Keybinds.tsx
+++ b/src/pages/settings/panes/Keybinds.tsx
@@ -112,23 +112,28 @@ const KeySequence = styled.kbd`
 `;
 
 // allow string to make easier to use
-type KeybindProps = {
-    children: string | KeyCombo[];
-    short?: boolean;
-    pressable?: boolean;
-};
-export const Keybind = ({
-    children: sequence,
-    short,
-    pressable,
-}: KeybindProps) => {
+type KeybindProps =
+    | (Omit<JSX.HTMLAttributes<HTMLElement>, "children" | "as"> & {
+          children: string | KeyCombo[];
+          short?: boolean;
+          pressable?: boolean;
+      })
+    | { action: KeybindAction; short?: boolean; pressable?: boolean };
+export const Keybind = ({ short, pressable, ...props }: KeybindProps) => {
+    const keybinds = useApplicationState().keybinds;
+
+    const sequence =
+        "children" in props
+            ? props.children
+            : keybinds.getKeybinds(props.action)[0].sequence;
+
     const keys =
         typeof sequence === "string"
             ? KeybindSequence.parse(sequence)
             : sequence;
 
     const kbds = keys.map((keybinding) => (
-        <kbd>
+        <kbd {...props}>
             {keybinding.map((mod, i) => [
                 i > 0 ? "+" : null,
                 <Key

--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -215,16 +215,10 @@ function BotCard({ bot, onDelete, onUpdate }: Props) {
         setSaving(false);
     }
 
-    const {
-        onChange,
-        onKeyUp,
-        onKeyDown,
-        onFocus,
-        onBlur,
-        ...autoCompleteProps
-    } = useAutoComplete(setContent, {
-        users: { type: "all" },
-    });
+    const { onChange, onKeyUp, onFocus, onBlur, ...autoCompleteProps } =
+        useAutoComplete(setContent, {
+            users: { type: "all" },
+        });
 
     return (
         <div key={bot._id} className={styles.botCard}>
@@ -427,7 +421,6 @@ function BotCard({ bot, onDelete, onUpdate }: Props) {
                                 }`,
                             )}
                             onKeyUp={onKeyUp}
-                            onKeyDown={onKeyDown}
                             onFocus={onFocus}
                             onBlur={onBlur}
                         />

--- a/src/pages/settings/panes/Profile.tsx
+++ b/src/pages/settings/panes/Profile.tsx
@@ -49,16 +49,10 @@ export const Profile = observer(() => {
         if (!changed) setChanged(true);
     }
 
-    const {
-        onChange,
-        onKeyUp,
-        onKeyDown,
-        onFocus,
-        onBlur,
-        ...autoCompleteProps
-    } = useAutoComplete(setContent, {
-        users: { type: "all" },
-    });
+    const { onChange, onKeyUp, onFocus, onBlur, ...autoCompleteProps } =
+        useAutoComplete(setContent, {
+            users: { type: "all" },
+        });
 
     return (
         <div className={styles.user}>
@@ -163,7 +157,6 @@ export const Profile = observer(() => {
                     }`,
                 )}
                 onKeyUp={onKeyUp}
-                onKeyDown={onKeyDown}
                 onFocus={onFocus}
                 onBlur={onBlur}
             />

--- a/src/pages/settings/server/Categories.tsx
+++ b/src/pages/settings/server/Categories.tsx
@@ -358,107 +358,116 @@ function ListElement({
     }, [editing, category.id, save]);
 
     return (
-        <Draggable
-            isDragDisabled={!draggable}
-            key={category.id}
-            draggableId={category.id}
-            index={index}>
-            {(provided) => (
-                <div {...provided.draggableProps} ref={provided.innerRef}>
-                    <KanbanList last={false} key={category.id}>
-                        <div class="inner">
-                            <Row>
-                                <KanbanListHeader {...provided.dragHandleProps}>
-                                    {editing ? (
-                                        <input
-                                            value={editing}
-                                            onChange={(e) =>
-                                                setEditing(
-                                                    e.currentTarget.value,
-                                                )
-                                            }
-                                            onKeyDown={(e) =>
-                                                e.key === "Enter" && save()
-                                            }
-                                            id={category.id}
-                                        />
-                                    ) : (
-                                        <span onClick={startEditing}>
-                                            {category.title}
-                                        </span>
-                                    )}
-                                </KanbanListHeader>
-                                {deleteSelf && (
-                                    <KanbanListHeader onClick={deleteSelf}>
-                                        <X size={24} />
+        <form
+            // when possible, use onSubmit instead of a keybind action for `Enter` or `InputSubmit`.
+            onSubmit={(e) => {
+                e.preventDefault();
+                save();
+            }}>
+            <Draggable
+                isDragDisabled={!draggable}
+                key={category.id}
+                draggableId={category.id}
+                index={index}>
+                {(provided) => (
+                    <div {...provided.draggableProps} ref={provided.innerRef}>
+                        <KanbanList last={false} key={category.id}>
+                            <div class="inner">
+                                <Row>
+                                    <KanbanListHeader
+                                        {...provided.dragHandleProps}>
+                                        {editing ? (
+                                            <input
+                                                value={editing}
+                                                onChange={(e) =>
+                                                    setEditing(
+                                                        e.currentTarget.value,
+                                                    )
+                                                }
+                                                id={category.id}
+                                            />
+                                        ) : (
+                                            <span onClick={startEditing}>
+                                                {category.title}
+                                            </span>
+                                        )}
                                     </KanbanListHeader>
-                                )}
-                            </Row>
-                            <Droppable
-                                droppableId={category.id}
-                                key={category.id}>
-                                {(provided) => (
-                                    <div
-                                        ref={provided.innerRef}
-                                        {...provided.droppableProps}>
-                                        {category.channels.map((x, index) => {
-                                            const channel =
-                                                server.client.channels.get(x);
-                                            if (!channel) return null;
+                                    {deleteSelf && (
+                                        <KanbanListHeader onClick={deleteSelf}>
+                                            <X size={24} />
+                                        </KanbanListHeader>
+                                    )}
+                                </Row>
+                                <Droppable
+                                    droppableId={category.id}
+                                    key={category.id}>
+                                    {(provided) => (
+                                        <div
+                                            ref={provided.innerRef}
+                                            {...provided.droppableProps}>
+                                            {category.channels.map(
+                                                (x, index) => {
+                                                    const channel =
+                                                        server.client.channels.get(
+                                                            x,
+                                                        );
+                                                    if (!channel) return null;
 
-                                            return (
-                                                <Draggable
-                                                    key={x}
-                                                    draggableId={x}
-                                                    index={index}>
-                                                    {(provided) => (
-                                                        <div
-                                                            {...provided.draggableProps}
-                                                            {...provided.dragHandleProps}
-                                                            ref={
-                                                                provided.innerRef
-                                                            }>
-                                                            <KanbanEntry>
-                                                                <div class="inner">
-                                                                    <ChannelIcon
-                                                                        target={
-                                                                            channel
-                                                                        }
-                                                                        size={
-                                                                            24
-                                                                        }
-                                                                    />
-                                                                    <span>
-                                                                        {
-                                                                            channel.name
-                                                                        }
-                                                                    </span>
+                                                    return (
+                                                        <Draggable
+                                                            key={x}
+                                                            draggableId={x}
+                                                            index={index}>
+                                                            {(provided) => (
+                                                                <div
+                                                                    {...provided.draggableProps}
+                                                                    {...provided.dragHandleProps}
+                                                                    ref={
+                                                                        provided.innerRef
+                                                                    }>
+                                                                    <KanbanEntry>
+                                                                        <div class="inner">
+                                                                            <ChannelIcon
+                                                                                target={
+                                                                                    channel
+                                                                                }
+                                                                                size={
+                                                                                    24
+                                                                                }
+                                                                            />
+                                                                            <span>
+                                                                                {
+                                                                                    channel.name
+                                                                                }
+                                                                            </span>
+                                                                        </div>
+                                                                    </KanbanEntry>
                                                                 </div>
-                                                            </KanbanEntry>
-                                                        </div>
-                                                    )}
-                                                </Draggable>
-                                            );
-                                        })}
-                                        {provided.placeholder}
-                                    </div>
-                                )}
-                            </Droppable>
-                            <KanbanListHeader
-                                onClick={() =>
-                                    openScreen({
-                                        id: "special_prompt",
-                                        type: "create_channel",
-                                        target: server,
-                                        cb: addChannel,
-                                    })
-                                }>
-                                <Plus size={24} />
-                            </KanbanListHeader>
-                        </div>
-                    </KanbanList>
-                </div>
-            )}
-        </Draggable>
+                                                            )}
+                                                        </Draggable>
+                                                    );
+                                                },
+                                            )}
+                                            {provided.placeholder}
+                                        </div>
+                                    )}
+                                </Droppable>
+                                <KanbanListHeader
+                                    onClick={() =>
+                                        openScreen({
+                                            id: "special_prompt",
+                                            type: "create_channel",
+                                            target: server,
+                                            cb: addChannel,
+                                        })
+                                    }>
+                                    <Plus size={24} />
+                                </KanbanListHeader>
+                            </div>
+                        </KanbanList>
+                    </div>
+                )}
+            </Draggable>
+        </form>
     );
 }


### PR DESCRIPTION
todo:
- [x] fix `ArrowUp` to edit previous message also triggering when `Alt+ArrowUp` or `Ctrl+Alt+ArrowUp` is pressed.
- [ ] add more keybinds
  - [ ] navigate between unreads
  - [ ] navigate between unread mentions
- [x] add keybind settings page (optional)

This adds basic navigation keybinds, some files got auto-formatted while making changes to them

resolves: #26, revoltchat/revolt#189