### PR TITLE
feat: emoji mouse-over display markup (:emoji:)

### DIFF
--- a/src/components/common/Emoji.tsx
+++ b/src/components/common/Emoji.tsx
@@ -1,3 +1,5 @@
+import Token from "markdown-it/lib/token";
+
 export type EmojiPack = "mutant" | "twemoji" | "noto" | "openmoji";
 
 let EMOJI_PACK: EmojiPack = "mutant";
@@ -72,8 +74,10 @@ export default function Emoji({
     );
 }
 
-export function generateEmoji(emoji: string) {
-    return `<img loading="lazy" class="emoji" draggable="false" alt="${emoji}" src="${parseEmoji(
+export function generateEmoji(emojiToken: Token) {
+    const emoji = emojiToken.content;
+    const emojiSource = ":" + emojiToken.markup + ":";
+    return `<img loading="lazy" class="emoji" draggable="false" title="${emojiSource}" alt="${emoji}" src="${parseEmoji(
         emoji,
     )}" />`;
 }

--- a/src/components/markdown/Renderer.tsx
+++ b/src/components/markdown/Renderer.tsx
@@ -17,6 +17,7 @@ import { useCallback, useContext } from "preact/hooks";
 import { internalEmit } from "../../lib/eventEmitter";
 import { determineLink } from "../../lib/links";
 
+import { dayjs } from "../../context/Locale";
 import { useIntermediate } from "../../context/intermediate/Intermediate";
 import { AppContext } from "../../context/revoltjs/RevoltClient";
 
@@ -25,8 +26,6 @@ import { generateEmoji } from "../common/Emoji";
 import { emojiDictionary } from "../../assets/emojis";
 import { MarkdownProps } from "./Markdown";
 import Prism from "./prism";
-
-import { dayjs } from "../../context/Locale";
 
 // TODO: global.d.ts file for defining globals
 declare global {
@@ -86,7 +85,7 @@ declare global {
 
 // Include emojis.
 md.renderer.rules.emoji = function (token, idx) {
-    return generateEmoji(token[idx].content);
+    return generateEmoji(token[idx]);
 };
 
 // Force line breaks.


### PR DESCRIPTION
See #494 for more info and screenshots.
Currently it simply implements the `title` tag of the `<img>` that is being generated for the markdown (`components/markdown/Renderer.tsx` --> `components/common/Emoji.tsx/generateEmoji`)