### PR TITLE
fix(components): add padding-right to markdown code element

### DIFF
--- a/src/components/markdown/Markdown.module.scss
+++ b/src/components/markdown/Markdown.module.scss
@@ -97,6 +97,7 @@
     code {
         color: white;
         font-size: 90%;
+        padding-right: 1em;
         background: var(--block);
         border-radius: var(--border-radius);
         font-family: var(--monospace-font), monospace;


### PR DESCRIPTION
Before:

![Screenshot_20220107_212114](https://user-images.githubusercontent.com/90600421/148582025-a9160fe5-d164-46f4-b9f0-66c78f06553a.png)

After:

![Screenshot_20220107_212149](https://user-images.githubusercontent.com/90600421/148582086-8cf7aeff-1b3c-4b0b-890c-6d3f2e2cc04d.png)

Closes #322﻿
