### PR TITLE
fix: properly detect ipados

### DIFF
--- a/src/pages/login/forms/FormLogin.tsx
+++ b/src/pages/login/forms/FormLogin.tsx
@@ -21,6 +21,7 @@ export function FormLogin() {
                 if (browser) {
                     let { name } = browser;
                     const { os } = browser;
+                    let isiPad;
                     if (window.isNative) {
                         friendly_name = `Revolt Desktop on ${os}`;
                     } else {
@@ -28,8 +29,12 @@ export function FormLogin() {
                             name = "safari";
                         } else if (name === "fxios") {
                             name = "firefox";
+                        } else if (name === "crios") {
+                            name = "chrome";
                         }
-                        friendly_name = `${name} on ${os}`;
+                        if (os === "Mac OS" && navigator.maxTouchPoints > 0)
+                            isiPad = true;
+                        friendly_name = `${name} on ${isiPad ? "iPadOS" : os}`;
                     }
                 } else {
                     friendly_name = "Unknown Device";

--- a/src/pages/settings/panes/Sessions.tsx
+++ b/src/pages/settings/panes/Sessions.tsx
@@ -92,7 +92,7 @@ export function Sessions() {
                 return <Android size={14} />;
             case /mac.*os/i.test(name):
                 return <Macos size={14} />;
-            case /ios/i.test(name):
+            case /i(Pad)os/i.test(name):
                 return <Apple size={14} />;
             case /windows/i.test(name):
                 return <Windows size={14} />;


### PR DESCRIPTION
Currently, iPadOS users are either detected as macOS users or (all iOS users if using Chrome) "Crios". This PR fixes detection for these.