### PR TITLE
chore: remove highlight.js, use node 16 for ci

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -19,7 +19,7 @@ runs:
         - name: Setup Node
           uses: actions/setup-node@v2
           with:
-              node-version: 15
+              node-version: 16
               cache: "yarn"
 
         - name: Install Dependencies and Build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: node:14-buster
+image: node:16-buster
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
         "eslint": "^7.28.0",
         "eslint-config-preact": "^1.1.4",
         "eventemitter3": "^4.0.7",
-        "highlight.js": "^11.0.1",
         "json-stringify-deterministic": "^1.0.2",
         "localforage": "^1.9.0",
         "lodash.defaultsdeep": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,11 +3119,6 @@ highlight.js@^10.7.2:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-highlight.js@^11.0.1:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.2.0.tgz#a7e3b8c1fdc4f0538b93b2dc2ddd53a40c6ab0f0"
-  integrity sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==
-
 history@^4.9.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"


### PR DESCRIPTION
## Description
This PR removes highlight.js, which is completely unused (for those unaware, we use Prism for code highlighting) and takes up install time/space. This PR also updates the CI to use Node 16.