### PR TITLE
fix: fix iOS regex

### DIFF
--- a/src/pages/settings/panes/Sessions.tsx
+++ b/src/pages/settings/panes/Sessions.tsx
@@ -92,7 +92,7 @@ export function Sessions() {
                 return <Android size={14} />;
             case /mac.*os/i.test(name):
                 return <Macos size={14} />;
-            case /i(Pad)os/i.test(name):
+            case /i(Pad)?os/i.test(name):
                 return <Apple size={14} />;
             case /windows/i.test(name):
                 return <Windows size={14} />;


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes

This PR fixes the i(Pad)OS regex to correctly detect iOS. This makes sure the Apple logo is displayed for both iOS and iPadOS.