### PR TITLE
WIP: add empty state for voice channels

### DIFF
--- a/src/pages/channels/Channel.tsx
+++ b/src/pages/channels/Channel.tsx
@@ -1,33 +1,31 @@
-import { Hash } from "@styled-icons/boxicons-regular";
-import { Ghost } from "@styled-icons/boxicons-solid";
 import { reaction } from "mobx";
 import { observer } from "mobx-react-lite";
+import { Text } from "preact-i18n";
+import { useEffect, useState } from "preact/hooks";
 import { Redirect, useParams } from "react-router-dom";
 import { Channel as ChannelI } from "revolt.js/dist/maps/Channels";
 import styled from "styled-components/macro";
 
-import { Text } from "preact-i18n";
-import { useEffect, useState } from "preact/hooks";
-
-import ErrorBoundary from "../../lib/ErrorBoundary";
-import { internalSubscribe } from "../../lib/eventEmitter";
-import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
-
-import { useApplicationState } from "../../mobx/State";
-import { SIDEBAR_MEMBERS } from "../../mobx/stores/Layout";
-
-import { useClient } from "../../context/revoltjs/RevoltClient";
+import { Hash } from "@styled-icons/boxicons-regular";
+import { Ghost } from "@styled-icons/boxicons-solid";
 
 import AgeGate from "../../components/common/AgeGate";
 import MessageBox from "../../components/common/messaging/MessageBox";
 import JumpToBottom from "../../components/common/messaging/bars/JumpToBottom";
 import NewMessages from "../../components/common/messaging/bars/NewMessages";
 import TypingIndicator from "../../components/common/messaging/bars/TypingIndicator";
-import { PageHeader } from "../../components/ui/Header";
-
 import RightSidebar from "../../components/navigation/RightSidebar";
+import { PageHeader } from "../../components/ui/Header";
+import { useClient } from "../../context/revoltjs/RevoltClient";
+import ErrorBoundary from "../../lib/ErrorBoundary";
+import { internalSubscribe } from "../../lib/eventEmitter";
+import { isTouchscreenDevice } from "../../lib/isTouchscreenDevice";
+import { voiceState } from "../../lib/vortex/VoiceState";
+import { useApplicationState } from "../../mobx/State";
+import { SIDEBAR_MEMBERS } from "../../mobx/stores/Layout";
 import ChannelHeader from "./ChannelHeader";
 import { MessageArea } from "./messaging/MessageArea";
+import { VoiceEmptyState } from "./voice/VoiceEmptyState";
 import VoiceHeader from "./voice/VoiceHeader";
 
 const ChannelMain = styled.div.attrs({ "data-component": "channel" })`
@@ -195,14 +193,17 @@ const TextChannel = observer(({ channel }: { channel: ChannelI }) => {
     );
 });
 
-function VoiceChannel({ channel }: { channel: ChannelI }) {
+const VoiceChannel = observer(({ channel }: { channel: ChannelI }) => {
     return (
         <>
             <ChannelHeader channel={channel} />
             <VoiceHeader id={channel._id} />
+            {voiceState.roomId !== channel._id ? (
+                <VoiceEmptyState channel={channel} />
+            ) : null}
         </>
     );
-}
+});
 
 function ChannelPlaceholder() {
     return (

--- a/src/pages/channels/voice/VoiceEmptyState.tsx
+++ b/src/pages/channels/voice/VoiceEmptyState.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from "preact/hooks";
+import { Channel as ChannelI } from "revolt.js/dist/maps/Channels";
+import styled from "styled-components";
+
+import Button from "../../../components/ui/Button";
+import { voiceState } from "../../../lib/vortex/VoiceState";
+
+const Wrapper = styled.div`
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
+
+const Content = styled.div`
+    text-align: center;
+    max-width: 640px;
+    margin: auto;
+`;
+
+const Title = styled.h1`
+    font-size: 40px;
+    font-weight: bold;
+    margin: 0 0 16px;
+`;
+
+const Label = styled.div`
+    font-size: 20px;
+    opacity: 0.75;
+`;
+
+const Buttons = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 24px;
+`;
+
+export interface VoiceEmptyStateProps {
+    channel: ChannelI;
+}
+
+export const VoiceEmptyState = ({ channel }: { channel: ChannelI }) => {
+    const connectToVoice = useCallback(async () => {
+        await voiceState.loadVoice();
+        voiceState.disconnect();
+        voiceState.connect(channel);
+    }, [channel]);
+
+    return (
+        <Wrapper>
+            <Content>
+                <Title>No one here yet</Title>
+                <Label>Be the first and join this voice channel.</Label>
+                <Buttons>
+                    <Button accent onClick={connectToVoice}>
+                        Join {channel.name}
+                    </Button>
+                </Buttons>
+            </Content>
+        </Wrapper>
+    );
+};


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [x] I have included screenshots to demonstrate my changes

---

This PR implements a simple "Empty State" if the voice channel is not joined yet. What I still need to implement is the voice channel header when you are not connected and there are users in the voice channel already. Is this already possible API wise?

Translations are also missing - I'll update the translations repository for strings.

---

Screenshot:

![image](https://user-images.githubusercontent.com/6538827/150454747-eaab305f-1933-4f0b-9f54-1f858e9acf70.png)

