### PR TITLE
Added new Chat Feature/Command /embed

### DIFF
--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -274,11 +274,23 @@ export default observer(({ channel }: Props) => {
             defer(() => renderer.jumpToBottom(SMOOTH_SCROLL_ON_RECEIVE));
 
             try {
+                if(content.startsWith("/embed ")) {
+                    
+                    
+                await channel.sendMessage({
+                    content: " ",
+                    nonce,
+                    replies,
+                    embeds: [{icon_url: "https://cdn-icons-png.flaticon.com/512/2099/2099058.png", type: "Text",title: "Embed Message", description: content.replace("/embed ","")}],
+                });
+            } else 
+            {
                 await channel.sendMessage({
                     content,
                     nonce,
                     replies,
                 });
+            }
             } catch (error) {
                 state.queue.fail(nonce, takeError(error));
             }

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -154,7 +154,8 @@ export default observer(({ channel }: Props) => {
                     <Action>
                         <PermissionTooltip
                             permission="SendMessages"
-                            placement="top">
+                            placement="top"
+                        >
                             <ShieldX size={22} />
                         </PermissionTooltip>
                     </Action>
@@ -274,23 +275,28 @@ export default observer(({ channel }: Props) => {
             defer(() => renderer.jumpToBottom(SMOOTH_SCROLL_ON_RECEIVE));
 
             try {
-                if(content.startsWith("/embed ")) {
-                    
-                    
-                await channel.sendMessage({
-                    content: " ",
-                    nonce,
-                    replies,
-                    embeds: [{icon_url: "https://cdn-icons-png.flaticon.com/512/2099/2099058.png", type: "Text",title: "Embed Message", description: content.replace("/embed ","")}],
-                });
-            } else 
-            {
-                await channel.sendMessage({
-                    content,
-                    nonce,
-                    replies,
-                });
-            }
+                if (content.startsWith("/embed ")) {
+                    await channel.sendMessage({
+                        content: " ",
+                        nonce,
+                        replies,
+                        embeds: [
+                            {
+                                icon_url:
+                                    "https://cdn-icons-png.flaticon.com/512/2099/2099058.png",
+                                type: "Text",
+                                title: "Embed Message",
+                                description: content.replace("/embed ", ""),
+                            },
+                        ],
+                    });
+                } else {
+                    await channel.sendMessage({
+                        content,
+                        nonce,
+                        replies,
+                    });
+                }
             } catch (error) {
                 state.queue.fail(nonce, takeError(error));
             }
@@ -617,7 +623,8 @@ export default observer(({ channel }: Props) => {
                     <IconButton
                         className="mobile"
                         onClick={send}
-                        onMouseDown={(e) => e.preventDefault()}>
+                        onMouseDown={(e) => e.preventDefault()}
+                    >
                         <Send size={20} />
                     </IconButton>
                 </Action>


### PR DESCRIPTION
now we can send embeds using /embed

Please note the Gear Icon needs to be replaced as it is hosted on a random vector website and we may want to add an option for raw embed JSON but I think that is to dangerous and complex(for non devs to use) to include in the client this icon is a placeholder anyway
here a demo of the client-side command
![image](https://user-images.githubusercontent.com/66263341/151071569-463e9946-1ced-4ac7-8895-a233e6cfed1e.png)

![image](https://user-images.githubusercontent.com/66263341/151071512-4f606e0f-1bb3-4a18-97f3-c5c3328a0dd7.png)

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes
