### PR TITLE
fix(messages): don't attempt to display revolt wiki link as invite

### DIFF
--- a/src/components/common/messaging/embed/EmbedInvite.tsx
+++ b/src/components/common/messaging/embed/EmbedInvite.tsx
@@ -194,7 +194,7 @@ const INVITE_PATHS = [
     "app.revolt.chat/invite",
     "nightly.revolt.chat/invite",
     "local.revolt.chat/invite",
-    "rvlt.gg",
+    "(?<!wiki.)rvlt.gg",
 ];
 
 const RE_INVITE = new RegExp(


### PR DESCRIPTION
* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
* [X] ~~(optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)~~
* [X] I have included screenshots to demonstrate my changes

## Current Behavior
![image](https://user-images.githubusercontent.com/45950794/159792570-e9dfe6a1-dd61-458a-a590-32843bca2fe4.png)

## Expected Behavior Implemented by PR
![image](https://user-images.githubusercontent.com/45950794/159792686-dd88cc87-9da5-4ac1-8116-9946916e30eb.png)

