### PR TITLE
feat: Implement a plugins page

### DIFF
--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components/macro";
 
 import { Children } from "../../types/Preact";
 
-const CheckboxBase = styled.label`
+export const CheckboxBase = styled.label`
     gap: 4px;
     z-index: 1;
     display: flex;
@@ -52,7 +52,7 @@ const CheckboxDescription = styled.span`
     color: var(--secondary-foreground);
 `;
 
-const Checkmark = styled.div<{ checked: boolean; contrast?: boolean }>`
+export const Checkmark = styled.div<{ checked: boolean; contrast?: boolean }>`
     margin: 4px;
     width: 24px;
     height: 24px;

--- a/src/mobx/stores/Plugins.ts
+++ b/src/mobx/stores/Plugins.ts
@@ -94,6 +94,18 @@ export default class Plugins implements Store, Persistent<Data> {
         return "revite:plugins";
     }
 
+    // lexisother: https://github.com/revoltchat/revite/pull/571#discussion_r836824601
+    list() {
+        return [...this.plugins.values()].map(
+            ({ namespace, id, version, enabled }) => ({
+                namespace,
+                id,
+                version,
+                enabled,
+            }),
+        );
+    }
+
     toJSON() {
         return {
             "revite:plugins": mapToRecord(this.plugins),
@@ -211,7 +223,7 @@ export default class Plugins implements Store, Persistent<Data> {
             loaded.onUnload?.();
             this.plugins.set(ns, {
                 ...plugin,
-                enabled: true,
+                enabled: false,
             });
         }
     }

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -166,8 +166,7 @@ export default observer(() => {
                 {
                     id: "plugins",
                     icon: <Plug size={20} />,
-                    // TODO(lexisother): Replace this with the actual i18n <Text />
-                    title: <p>Plugins</p>,
+                    title: <Text id="app.settings.pages.plugins.title" />,
                     hidden: !experiments.isEnabled("plugins"),
                 },
                 {

--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -15,7 +15,7 @@ import {
     User,
     Megaphone,
     Speaker,
-    Store,
+    Plug,
     Bot,
     Trash,
 } from "@styled-icons/boxicons-solid";
@@ -53,6 +53,7 @@ import { Languages } from "./panes/Languages";
 import { MyBots } from "./panes/MyBots";
 import { Native } from "./panes/Native";
 import { Notifications } from "./panes/Notifications";
+import { PluginsPage } from "./panes/Plugins";
 import { Profile } from "./panes/Profile";
 import { Sessions } from "./panes/Sessions";
 import { Sync } from "./panes/Sync";
@@ -163,6 +164,13 @@ export default observer(() => {
                     title: <Text id="app.settings.pages.appearance.title" />,
                 },
                 {
+                    id: "plugins",
+                    icon: <Plug size={20} />,
+                    // TODO(lexisother): Replace this with the actual i18n <Text />
+                    title: <p>Plugins</p>,
+                    hidden: !experiments.isEnabled("plugins"),
+                },
+                {
                     id: "notifications",
                     icon: <Bell size={20} />,
                     title: <Text id="app.settings.pages.notifications.title" />,
@@ -213,6 +221,9 @@ export default observer(() => {
                     </Route>
                     <Route path="/settings/appearance">
                         <Appearance />
+                    </Route>
+                    <Route path="/settings/plugins">
+                        <PluginsPage />
                     </Route>
                     <Route path="/settings/audio">
                         <Audio />

--- a/src/pages/settings/panes/Panes.module.scss
+++ b/src/pages/settings/panes/Panes.module.scss
@@ -528,6 +528,12 @@
     }
 }
 
+.plugins {
+    h1 {
+        margin-bottom: 20px !important;
+    }
+}
+
 .myBots {
     margin-top: 10px;
     .botList {

--- a/src/pages/settings/panes/Panes.module.scss
+++ b/src/pages/settings/panes/Panes.module.scss
@@ -532,6 +532,13 @@
     h1 {
         margin-bottom: 20px !important;
     }
+
+    .empty {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-top: 1rem;
+    }
 }
 
 .myBots {

--- a/src/pages/settings/panes/Plugins.tsx
+++ b/src/pages/settings/panes/Plugins.tsx
@@ -1,0 +1,36 @@
+import { observer } from "mobx-react-lite";
+
+import styles from "./Panes.module.scss";
+
+import { useApplicationState } from "../../../mobx/State";
+
+import Checkbox from "../../../components/ui/Checkbox";
+import Tip from "../../../components/ui/Tip";
+
+export const PluginsPage = observer(() => {
+    const plugins = useApplicationState().plugins;
+    return (
+        <div className={styles.plugins}>
+            {/* TODO(lexisother): Wrap in <h3><Text /></h3> */}
+            <h1>Plugins</h1>
+            <Tip error hideSeparator>
+                Warning: This feature is still in development.
+            </Tip>
+            {plugins.list().map((plugin) => {
+                return (
+                    <Checkbox
+                        key={plugin.id}
+                        checked={plugin.enabled!}
+                        onChange={() => {
+                            !plugin.enabled
+                                ? plugins.load(plugin.namespace, plugin.id)
+                                : plugins.unload(plugin.namespace, plugin.id);
+                        }}
+                        description={""}>
+                        {plugin.namespace} / {plugin.id}
+                    </Checkbox>
+                );
+            })}
+        </div>
+    );
+});

--- a/src/pages/settings/panes/Plugins.tsx
+++ b/src/pages/settings/panes/Plugins.tsx
@@ -88,10 +88,11 @@ function PluginCard({ plugin }: CardProps) {
                 </div>
                 <div className={styles.buttonRow}>
                     <Button
+                        error
                         onClick={() =>
                             plugins.remove(plugin.namespace, plugin.id)
                         }>
-                        <p>Delete</p>
+                        <Text id="app.settings.pages.plugins.delete_plugin" />
                     </Button>
                 </div>
             </div>
@@ -104,7 +105,7 @@ export const PluginsPage = observer(() => {
     return (
         <div className={styles.plugins}>
             <Tip error hideSeparator>
-                Warning: This feature is still in development.
+                <Text id="app.settings.pages.plugins.wip" />
             </Tip>
             {plugins.list().map((plugin) => {
                 return <PluginCard key={plugin.id} plugin={plugin} />;

--- a/src/pages/settings/panes/Plugins.tsx
+++ b/src/pages/settings/panes/Plugins.tsx
@@ -1,12 +1,103 @@
+import { Check } from "@styled-icons/boxicons-regular";
 import { observer } from "mobx-react-lite";
+import styled from "styled-components";
 
 import styles from "./Panes.module.scss";
 import { Text } from "preact-i18n";
 
 import { useApplicationState } from "../../../mobx/State";
 
-import Checkbox from "../../../components/ui/Checkbox";
+import Button from "../../../components/ui/Button";
+import { CheckboxBase, Checkmark } from "../../../components/ui/Checkbox";
 import Tip from "../../../components/ui/Tip";
+
+// Just keeping this here for general purpose. Should probably be exported
+// elsewhere, though.
+interface Plugin {
+    namespace: string;
+    id: string;
+    version: string;
+    enabled: boolean | undefined;
+}
+
+const CustomCheckboxBase = styled(CheckboxBase)`
+    margin-top: 0 !important;
+`;
+export interface CheckboxProps {
+    checked: boolean;
+    disabled?: boolean;
+    onChange: (state: boolean) => void;
+}
+function PluginCheckbox(props: CheckboxProps) {
+    // HACK HACK HACK(lexisother): THIS ENTIRE THING IS A HACK!!!!
+    /*
+        Until some reviewer points me in the right direction, I've resorted to
+         fabricating my own checkbox component.
+       "WHY?!", you might ask. Well, the normal `Checkbox` component can take
+         textual contents, and *also* adds a `margin-top` of 20 pixels.
+        We... don't need that. At all. *Especially* the margin. It makes our card
+         look disproportionate.
+        
+        Apologies, @insert!
+    */
+    return (
+        <CustomCheckboxBase disabled={props.disabled}>
+            <input
+                type="checkbox"
+                checked={props.checked}
+                onChange={() =>
+                    !props.disabled && props.onChange(!props.checked)
+                }
+            />
+            <Checkmark checked={props.checked} className="check">
+                <Check size={20} />
+            </Checkmark>
+        </CustomCheckboxBase>
+    );
+}
+
+interface CardProps {
+    plugin: Plugin;
+}
+function PluginCard({ plugin }: CardProps) {
+    const plugins = useApplicationState().plugins;
+
+    // TODO(lexisother): ...don't hijack bot cards? We need a general-purpose
+    // card component.
+    return (
+        <div className={styles.myBots}>
+            <div key={plugin.id} className={styles.botCard}>
+                <div className={styles.infocontainer}>
+                    <div className={styles.infoheader}>
+                        <div className={styles.container}>
+                            {plugin.namespace} / {plugin.id}
+                        </div>
+                        <PluginCheckbox
+                            key={plugin.id}
+                            checked={plugin.enabled!}
+                            onChange={() => {
+                                !plugin.enabled
+                                    ? plugins.load(plugin.namespace, plugin.id)
+                                    : plugins.unload(
+                                          plugin.namespace,
+                                          plugin.id,
+                                      );
+                            }}
+                        />
+                    </div>
+                </div>
+                <div className={styles.buttonRow}>
+                    <Button
+                        onClick={() =>
+                            plugins.remove(plugin.namespace, plugin.id)
+                        }>
+                        <p>Delete</p>
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}
 
 export const PluginsPage = observer(() => {
     const plugins = useApplicationState().plugins;
@@ -16,20 +107,7 @@ export const PluginsPage = observer(() => {
                 Warning: This feature is still in development.
             </Tip>
             {plugins.list().map((plugin) => {
-                // TODO(lexisother): Stop using Checkbox, write a custom component
-                return (
-                    <Checkbox
-                        key={plugin.id}
-                        checked={plugin.enabled!}
-                        onChange={() => {
-                            !plugin.enabled
-                                ? plugins.load(plugin.namespace, plugin.id)
-                                : plugins.unload(plugin.namespace, plugin.id);
-                        }}
-                        description={""}>
-                        {plugin.namespace} / {plugin.id}
-                    </Checkbox>
-                );
+                return <PluginCard key={plugin.id} plugin={plugin} />;
             })}
 
             {plugins.list().length === 0 && (

--- a/src/pages/settings/panes/Plugins.tsx
+++ b/src/pages/settings/panes/Plugins.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 
 import styles from "./Panes.module.scss";
+import { Text } from "preact-i18n";
 
 import { useApplicationState } from "../../../mobx/State";
 
@@ -11,12 +12,11 @@ export const PluginsPage = observer(() => {
     const plugins = useApplicationState().plugins;
     return (
         <div className={styles.plugins}>
-            {/* TODO(lexisother): Wrap in <h3><Text /></h3> */}
-            <h1>Plugins</h1>
             <Tip error hideSeparator>
                 Warning: This feature is still in development.
             </Tip>
             {plugins.list().map((plugin) => {
+                // TODO(lexisother): Stop using Checkbox, write a custom component
                 return (
                     <Checkbox
                         key={plugin.id}
@@ -31,6 +31,12 @@ export const PluginsPage = observer(() => {
                     </Checkbox>
                 );
             })}
+
+            {plugins.list().length === 0 && (
+                <div className={styles.empty}>
+                    <Text id="app.settings.pages.plugins.no_plugins" />
+                </div>
+            )}
         </div>
     );
 });


### PR DESCRIPTION
Does what it says on the tin. Note this is heavily WIP, and further PRs will (probably) follow.

However, depending on how the PR is received by whoever reviews it, development of the plugins page can continue here by turning the PR into a draft.

A related PR has been made on the [translation repository](https://github.com/revoltchat/translations/pull/30).

### TODOs

- [x] Submit the translation PR
- [x] Replace the hard coded paragraphs and headers with i18n text components

---

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [x] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

(not exactly a screenshot, but I hope this suffices)

https://user-images.githubusercontent.com/54973868/160474001-dd08492e-fe26-464d-ba1d-9e5f72f59063.mp4


