### PR TITLE
fix(components): wrong calculation of dimensions of embeds layouts

### DIFF
--- a/src/components/common/messaging/embed/Embed.tsx
+++ b/src/components/common/messaging/embed/Embed.tsx
@@ -59,7 +59,7 @@ export default function Embed({ embed }: Props) {
 
             if (embed.type === "Text") {
                 mw = MAX_EMBED_WIDTH;
-                mh = 0;
+                mh = 1;
             } else {
                 switch (embed.special?.type) {
                     case "YouTube":

--- a/src/context/revoltjs/FileUploads.tsx
+++ b/src/context/revoltjs/FileUploads.tsx
@@ -244,6 +244,9 @@ export function FileUploader(props: Props) {
                     [styles.icon]: style === "icon",
                     [styles.banner]: style === "banner",
                 })}
+                style={{
+                    alignItems: props.style === "icon" ? "center" : "none",
+                }}
                 data-uploading={uploading}>
                 <div
                     className={classNames(

--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -296,6 +296,7 @@ function BotCard({ bot, onDelete, onUpdate }: Props) {
                             </div>
                         ) : (
                             <InputBox
+                                style={{ width: "100%" }}
                                 ref={setUsernameRef}
                                 value={data.username}
                                 disabled={saving}

--- a/src/pages/settings/panes/MyBots.tsx
+++ b/src/pages/settings/panes/MyBots.tsx
@@ -582,8 +582,9 @@ export const MyBots = observer(() => {
                                                 x.interactions_url =
                                                     changes.interactions_url;
                                             if (
-                                                changes.remove ===
-                                                ["InteractionsURL"]
+                                                changes.remove?.includes(
+                                                    "InteractionsURL",
+                                                )
                                             )
                                                 x.interactions_url = undefined;
                                         }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

## Before
![image](https://user-images.githubusercontent.com/56084970/167326746-b5f6917e-fadc-4bbd-aad3-43d470c8baaa.png)

![image](https://user-images.githubusercontent.com/56084970/167328176-15fa5dc0-ec66-40c1-a4a6-18d9c239e4c1.png)

## After
![image](https://user-images.githubusercontent.com/56084970/167326755-1c9ee98b-1356-45af-aafa-a2960c1470fc.png)

![image](https://user-images.githubusercontent.com/56084970/167328202-59cabcd2-0482-4408-afee-1c645c34f804.png)


