### PR TITLE
feat: Add option to show Send button on Desktop

### DIFF
--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -637,7 +637,11 @@ export default observer(({ channel }: Props) => {
                 </Action>*/}
                 <Action>
                     <IconButton
-                        className="mobile"
+                        className={
+                            state.settings.get("appearance:show_send_button")
+                                ? ""
+                                : "mobile"
+                        }
                         onClick={send}
                         onMouseDown={(e) => e.preventDefault()}>
                         <Send size={20} />

--- a/src/components/settings/AppearanceShims.tsx
+++ b/src/components/settings/AppearanceShims.tsx
@@ -212,6 +212,24 @@ export const DisplayLigaturesShim = observer(() => {
 });
 
 /**
+ * Component providing a way to toggle showing the send button on desktop.
+ */
+export const ShowSendButtonShim = observer(() => {
+    const settings = useApplicationState().settings;
+
+    return (
+        <Checkbox
+            checked={settings.get("appearance:show_send_button") ?? false}
+            onChange={(v) => settings.set("appearance:show_send_button", v)}
+            description={
+                <Text id="app.settings.pages.appearance.appearance_options.show_send_desc" />
+            }>
+            <Text id="app.settings.pages.appearance.appearance_options.show_send" />
+        </Checkbox>
+    );
+});
+
+/**
  * Component providing a way to toggle seasonal themes.
  */
 export const DisplaySeasonalShim = observer(() => {

--- a/src/mobx/stores/Settings.ts
+++ b/src/mobx/stores/Settings.ts
@@ -30,6 +30,7 @@ export interface ISettings {
     "appearance:ligatures": boolean;
     "appearance:seasonal": boolean;
     "appearance:transparency": boolean;
+    "appearance:show_send_button": boolean;
 
     "appearance:theme:base": "dark" | "light";
     "appearance:theme:overrides": Partial<Overrides>;

--- a/src/pages/settings/panes/Appearance.tsx
+++ b/src/pages/settings/panes/Appearance.tsx
@@ -16,6 +16,7 @@ import {
     ThemeCustomCSSShim,
     DisplaySeasonalShim,
     DisplayTransparencyShim,
+    ShowSendButtonShim,
 } from "../../../components/settings/AppearanceShims";
 import ThemeOverrides from "../../../components/settings/appearance/ThemeOverrides";
 import ThemeTools from "../../../components/settings/appearance/ThemeTools";
@@ -27,6 +28,11 @@ export const Appearance = observer(() => {
             <ThemeShopShim />
             <hr />
             <ThemeAccentShim />
+            <hr />
+            <h3>
+                <Text id="app.settings.pages.appearance.appearance_options.title" />
+            </h3>
+            <ShowSendButtonShim />
             <hr />
             <h3>
                 <Text id="app.settings.pages.appearance.theme_options.title" />


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [x] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

PR to translation repo will follow.

Adds a toggle to display the Send Message button in the message box on Desktop:

![image](https://user-images.githubusercontent.com/26145882/168066975-14b7477a-925c-4b46-b57b-01a271708650.png)
![image](https://user-images.githubusercontent.com/26145882/168067090-4c628f56-a4cd-488c-8e83-e4e4dc462622.png)
