### PR TITLE
fix: display voice channel as link in messages

### DIFF
--- a/src/components/markdown/Renderer.tsx
+++ b/src/components/markdown/Renderer.tsx
@@ -17,9 +17,8 @@ import { dayjs } from "../../context/Locale";
 import { useIntermediate } from "../../context/intermediate/Intermediate";
 import { AppContext } from "../../context/revoltjs/RevoltClient";
 
-import { generateEmoji } from "../common/Emoji";
-
 import { emojiDictionary } from "../../assets/emojis";
+import { generateEmoji } from "../common/Emoji";
 import { MarkdownProps } from "./Markdown";
 import Prism from "./prism";
 

--- a/src/components/markdown/Renderer.tsx
+++ b/src/components/markdown/Renderer.tsx
@@ -169,7 +169,10 @@ export default function Renderer({ content, disallowBigEmoji }: MarkdownProps) {
             const id = args[0] as string,
                 channel = client.channels.get(id);
 
-            if (channel?.channel_type === "TextChannel") {
+            if (
+                channel?.channel_type === "TextChannel" ||
+                channel?.channel_type === "VoiceChannel"
+            ) {
                 return `[#${channel.name}](/server/${channel.server_id}/channel/${id})`;
             }
 


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

Before:
![image](https://user-images.githubusercontent.com/38331868/171998288-2b4f34e6-2887-4328-88fb-26d66453705a.png)

After:
![image](https://user-images.githubusercontent.com/38331868/171998461-cae8a0f5-7305-4625-9bc4-1042ac0ca4cc.png)

also, wouldn't it be better to add a prefix (e.g. a "person speaking" icon) to indicate that the link is a voice channel?