### PR TITLE
fix: bug where PWA doesn't respect safe area (Home Indicator)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <!--App Scaling-->
         <meta
             name="viewport"
-            content="width=device-width, initial-scale=1.0, user-scalable=no"
+            content="width=device-width, initial-scale=1.0, user-scalable=no viewport-fit=cover"
         />
         <meta name="apple-mobile-web-app-capable" content="yes" />
 

--- a/src/components/common/messaging/MessageBox.tsx
+++ b/src/components/common/messaging/MessageBox.tsx
@@ -68,6 +68,7 @@ const Base = styled.div`
     display: flex;
     align-items: flex-start;
     background: var(--message-box);
+    padding-bottom: env(safe-area-inset-bottom);
 
     textarea {
         font-size: var(--text-size);


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

Related #370


Before:
![Before Image](https://user-images.githubusercontent.com/15057172/139744761-68353266-c2a9-4254-a4de-e4aa1baf3b9e.png)
![Before Image](https://user-images.githubusercontent.com/15057172/139744769-e747f46a-5ea4-45ef-99c1-209406005220.png)
Source  #370

After:
![After Image](https://user-images.githubusercontent.com/38331868/172060804-5eca3baa-48d8-4aaa-9f81-f7fc917aea37.png)
![After Image](https://user-images.githubusercontent.com/38331868/172060129-dd060bcf-3155-4e79-8998-b01b7b71d31f.jpg)

The first case (MessageBox) was fixed in commit b6cafcfc7f14dfe141a7ec3777aea2c7c8c149bf
by adding `padding-bottom` with value of `env(safe-area-inset-bottom)`

As for the second case (BottomNavigation), adding the same styles as the first case introduces a new problem:
It solves the issue of respecting the safe area
![5253932484612177441_121](https://user-images.githubusercontent.com/38331868/172060556-2165502b-19ad-4cca-bfd8-b4e43613a231.jpg)

but it breaks the following:
![5253932484612177442_121](https://user-images.githubusercontent.com/38331868/172060564-1cc4d8bb-977a-496a-bf2c-f11144b7368a.jpg)
which is caused by:
https://github.com/revoltchat/revite/blob/12b97160433151c188b077bd3e85fc2ee35bbd99/src/pages/RevoltApp.tsx#L157-L161

and for that to be solved, the `height` prop would need to somehow account for `env(safe-area-inset-bottom)`
so it would look somewhat like this, `50 + getSafeAreaInsetBottom()`
and `getSafeAreaInsetBottom()`, can be anything from an [external library](https://www.npmjs.com/package/safe-area-insets) to an implementation somewhere in the codebase, or maybe there's another way?

