### PR TITLE
fix: large images in website previews escape embed box

### DIFF
--- a/src/components/common/messaging/embed/Embed.module.scss
+++ b/src/components/common/messaging/embed/Embed.module.scss
@@ -13,7 +13,6 @@
 
     &.website {
         gap: 6px;
-        display: flex;
         flex-direction: row;
 
         > div:nth-child(1) {

--- a/src/components/common/messaging/embed/EmbedMedia.tsx
+++ b/src/components/common/messaging/embed/EmbedMedia.tsx
@@ -115,7 +115,7 @@ export default function EmbedMedia({ embed, width, height }: Props) {
                         className={styles.image}
                         src={client.proxyFile(url)}
                         loading="lazy"
-                        style={{ width, height }}
+                        style={{ width: "100%", height: "100%" }}
                         onClick={() =>
                             openScreen({
                                 id: "image_viewer",


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contrib
ution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

Fixes #692

![image](https://user-images.githubusercontent.com/44662495/174102231-e1d837f9-bfda-4640-8e5b-7631844c001c.png)