### PR TITLE
fix: category title input reverts to span on empty string

### DIFF
--- a/src/pages/settings/server/Categories.tsx
+++ b/src/pages/settings/server/Categories.tsx
@@ -344,11 +344,13 @@ function ListElement({
 
     const save = useCallback(() => {
         setEditing(undefined);
-        setTitle!(editing!);
+        if (editing !== "") {
+            setTitle!(editing!);
+        }
     }, [editing, setTitle]);
 
     useEffect(() => {
-        if (!editing) return;
+        if (editing === undefined) return;
 
         function onClick(ev: MouseEvent) {
             if ((ev.target as HTMLElement)?.id !== category.id) {
@@ -372,7 +374,7 @@ function ListElement({
                         <div className="inner">
                             <Row>
                                 <KanbanListHeader {...provided.dragHandleProps}>
-                                    {editing ? (
+                                    {editing !== undefined ? (
                                         <input
                                             value={editing}
                                             onChange={(e) =>


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

Fixes #693 
Read more https://github.com/revoltchat/revite/issues/693#issuecomment-1156718105 https://github.com/revoltchat/revite/issues/693#issuecomment-1156735269

Preview:
![image previewing editing a category with current empty name](https://user-images.githubusercontent.com/38331868/174445063-88f35c8e-0ea5-4d89-8201-1e908072f16d.png)

