### PR TITLE
feat: show server description when clicking its name

### DIFF
--- a/src/components/common/ServerBadge.tsx
+++ b/src/components/common/ServerBadge.tsx
@@ -1,0 +1,66 @@
+import Tooltip from "./Tooltip";
+import { Server } from "revolt.js";
+
+import { Text } from "preact-i18n";
+import { Check } from "@styled-icons/boxicons-regular";
+
+type Props = {
+	server: Server, 
+};
+
+export default function ServerBadge(props: Props) {
+
+	const { server } = props;
+
+	if (!server.flags) return undefined;
+
+	if (server.flags & 1) {
+			return (<Tooltip
+                        content={
+                            <Text id="app.special.server-badges.official" />
+                        }
+                        placement={"bottom-start"}>
+                        <svg width="20" height="20">
+                            <image
+                                xlinkHref="/assets/badges/verified.svg"
+                                height="20"
+                                width="20"
+                            />
+                            <image
+                                xlinkHref="/assets/badges/revolt_r.svg"
+                                height="15"
+                                width="15"
+                                x="2"
+                                y="3"
+                                style={
+                                    "justify-content: center; align-items: center; filter: brightness(0);"
+                                }
+                            />
+                        </svg>
+					</Tooltip>);
+	}
+	if (server.flags & 2) {
+			return (
+                    <Tooltip
+                        content={
+                            <Text id="app.special.server-badges.verified" />
+                        }
+                        placement={"bottom-start"}>
+                        <svg width="20" height="20">
+                            <image
+                                xlinkHref="/assets/badges/verified.svg"
+                                height="20"
+                                width="20"
+                            />
+                            <foreignObject x="2" y="2" width="15" height="15">
+                                <Check
+                                    size={15}
+                                    color="black"
+                                    strokeWidth={8}
+                                />
+                            </foreignObject>
+                        </svg>
+                    </Tooltip>
+				);
+	}
+}

--- a/src/components/common/ServerHeader.tsx
+++ b/src/components/common/ServerHeader.tsx
@@ -6,6 +6,8 @@ import styled, { css } from "styled-components/macro";
 
 import { IconButton } from "@revoltchat/ui";
 
+import { useIntermediate } from "../../context/intermediate/Intermediate";
+
 import ServerBadge from "./ServerBadge";
 
 interface Props {
@@ -63,6 +65,8 @@ const ServerBanner = styled.div<Omit<Props, "server">>`
 
 export default observer(({ server }: Props) => {
 
+    const { openScreen } = useIntermediate();
+
     const bannerURL = server.generateBannerURL({ width: 480 });
 
     return (
@@ -73,7 +77,13 @@ export default observer(({ server }: Props) => {
             }}>
             <div className="container">
 				<ServerBadge server={server} />
-				<div className="title">{server.name}</div>
+				<div className="title"
+					onClick={() => 
+						openScreen({
+							id: "server_info", 
+							server, 
+						})
+					}>{server.name}</div>
                 {server.havePermission("ManageServer") && (
                     <Link to={`/server/${server._id}/settings`}>
                         <IconButton>

--- a/src/components/common/ServerHeader.tsx
+++ b/src/components/common/ServerHeader.tsx
@@ -1,15 +1,12 @@
-import { Check } from "@styled-icons/boxicons-regular";
 import { Cog } from "@styled-icons/boxicons-solid";
 import { observer } from "mobx-react-lite";
 import { Link } from "react-router-dom";
 import { Server } from "revolt.js";
 import styled, { css } from "styled-components/macro";
 
-import { Text } from "preact-i18n";
-
 import { IconButton } from "@revoltchat/ui";
 
-import Tooltip from "./Tooltip";
+import ServerBadge from "./ServerBadge";
 
 interface Props {
     server: Server;
@@ -65,6 +62,7 @@ const ServerBanner = styled.div<Omit<Props, "server">>`
 `;
 
 export default observer(({ server }: Props) => {
+
     const bannerURL = server.generateBannerURL({ width: 480 });
 
     return (
@@ -74,54 +72,8 @@ export default observer(({ server }: Props) => {
                 backgroundImage: bannerURL ? `url('${bannerURL}')` : undefined,
             }}>
             <div className="container">
-                {server.flags && server.flags & 1 ? (
-                    <Tooltip
-                        content={
-                            <Text id="app.special.server-badges.official" />
-                        }
-                        placement={"bottom-start"}>
-                        <svg width="20" height="20">
-                            <image
-                                xlinkHref="/assets/badges/verified.svg"
-                                height="20"
-                                width="20"
-                            />
-                            <image
-                                xlinkHref="/assets/badges/revolt_r.svg"
-                                height="15"
-                                width="15"
-                                x="2"
-                                y="3"
-                                style={
-                                    "justify-content: center; align-items: center; filter: brightness(0);"
-                                }
-                            />
-                        </svg>
-                    </Tooltip>
-                ) : undefined}
-                {server.flags && server.flags & 2 ? (
-                    <Tooltip
-                        content={
-                            <Text id="app.special.server-badges.verified" />
-                        }
-                        placement={"bottom-start"}>
-                        <svg width="20" height="20">
-                            <image
-                                xlinkHref="/assets/badges/verified.svg"
-                                height="20"
-                                width="20"
-                            />
-                            <foreignObject x="2" y="2" width="15" height="15">
-                                <Check
-                                    size={15}
-                                    color="black"
-                                    strokeWidth={8}
-                                />
-                            </foreignObject>
-                        </svg>
-                    </Tooltip>
-                ) : undefined}
-                <div className="title">{server.name}</div>
+				<ServerBadge server={server} />
+				<div className="title">{server.name}</div>
                 {server.havePermission("ManageServer") && (
                     <Link to={`/server/${server._id}/settings`}>
                         <IconButton>

--- a/src/context/intermediate/Popovers.tsx
+++ b/src/context/intermediate/Popovers.tsx
@@ -4,6 +4,7 @@ import { IntermediateContext, useIntermediate } from "./Intermediate";
 import { SpecialInputModal } from "./modals/Input";
 import { SpecialPromptModal } from "./modals/Prompt";
 import { ChannelInfo } from "./popovers/ChannelInfo";
+import { ServerInfo } from "./popovers/ServerInfo";
 import { CreateBotModal } from "./popovers/CreateBot";
 import { ImageViewer } from "./popovers/ImageViewer";
 import { UserPicker } from "./popovers/UserPicker";
@@ -30,6 +31,9 @@ export default function Popovers() {
         case "channel_info":
             // @ts-expect-error someone figure this out :)
             return <ChannelInfo {...screen} onClose={onClose} />;
+        case "server_info":
+            // @ts-expect-error someone figure this out :)
+            return <ServerInfo {...screen} onClose={onClose} />;
         case "create_bot":
             // @ts-expect-error someone figure this out :)
             return <CreateBotModal onClose={onClose} {...screen} />;

--- a/src/context/intermediate/popovers/ServerInfo.module.scss
+++ b/src/context/intermediate/popovers/ServerInfo.module.scss
@@ -1,0 +1,17 @@
+.info {
+    .header {
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+
+        h1 {
+            margin: 0;
+            flex-grow: 1;
+        }
+
+        div {
+            cursor: pointer;
+        }
+    }
+}
+

--- a/src/context/intermediate/popovers/ServerInfo.tsx
+++ b/src/context/intermediate/popovers/ServerInfo.tsx
@@ -1,0 +1,45 @@
+import { X } from "@styled-icons/boxicons-regular";
+import { observer } from "mobx-react-lite";
+import { Server } from "revolt.js";
+
+import styles from "./ServerInfo.module.scss";
+
+import { Modal } from "@revoltchat/ui";
+
+import Markdown from "../../../components/markdown/Markdown";
+import { getChannelName } from "../../revoltjs/util";
+
+import ServerBadge from "../../../components/common/ServerBadge";
+
+interface Props {
+    server: Server;
+    onClose: () => void;
+}
+
+export const ServerInfo = observer(({ server, onClose }: Props) => {
+
+	//const bannerURL = server.generateBannerURL({ width: 480 });
+
+    return (
+		<Modal onClose={onClose}
+			// this looks like shit with most banners
+			//style={{
+			//	backgroundImage: bannerURL ? `url('${bannerURL}')` : undefined,
+			//}}
+			>
+            <div className={styles.info}>
+                <div className={styles.header}>
+					<ServerBadge server={server} />
+                    <h1>{server.name}</h1>
+                    <div onClick={onClose}>
+                        <X size={36} />
+                    </div>
+                </div>
+                <p>
+                    <Markdown content={server.description!} />
+                </p>
+            </div>
+        </Modal>
+    );
+});
+


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

This implements part of #41, I'll try to add the server description to the invites later maybe IDK.

[Here](https://user-images.githubusercontent.com/64381190/174757435-1231ab93-0963-4c35-9d6f-d15391f49f87.mp4)'s the video of how this looks in Firefox Nightly, also tested in Ungoogled Chromium and Epiphany, all work great.