### PR TITLE
fix: render HTML tags with markdown correctly

### DIFF
--- a/src/components/markdown/RemarkRenderer.tsx
+++ b/src/components/markdown/RemarkRenderer.tsx
@@ -135,8 +135,8 @@ const components = {
  */
 const render = unified()
     .use(remarkParse)
-    .use(remarkRemoveEscapeCharacter)
     .use(remarkBreaks)
+    .use(remarkRemoveEscapeCharacter)
     .use(remarkGfm)
     .use(remarkMath)
     .use(remarkSpoiler)

--- a/src/components/markdown/RemarkRenderer.tsx
+++ b/src/components/markdown/RemarkRenderer.tsx
@@ -22,6 +22,10 @@ import { remarkChannels, RenderChannel } from "./plugins/channels";
 import { isOnlyEmoji, remarkEmoji, RenderEmoji } from "./plugins/emoji";
 import { remarkHtmlToText } from "./plugins/htmlToText";
 import { remarkMention, RenderMention } from "./plugins/mentions";
+import {
+    remarkRemoveEscapeCharacter,
+    ESCAPE_CHARACTER,
+} from "./plugins/removeEscapeCharacter";
 import { remarkSpoiler, RenderSpoiler } from "./plugins/spoiler";
 import { remarkTimestamps } from "./plugins/timestamps";
 import "./prism";
@@ -131,6 +135,7 @@ const components = {
  */
 const render = unified()
     .use(remarkParse)
+    .use(remarkRemoveEscapeCharacter)
     .use(remarkBreaks)
     .use(remarkGfm)
     .use(remarkMath)
@@ -185,6 +190,11 @@ const Container = styled.div<{ largeEmoji: boolean }>`
 const RE_QUOTE = /(^(?:>\s){5})[>\s]+(.*$)/gm;
 
 /**
+ * Regex for matching HTML tags
+ */
+const RE_HTML_TAGS = /^(<\/?[a-zA-Z0-9]+>)(.*$)/gm;
+
+/**
  * Sanitise Markdown input before rendering
  * @param content Input string
  * @returns Sanitised string
@@ -194,6 +204,9 @@ function sanitise(content: string) {
         content
             // Strip excessive blockquote indentation
             .replace(RE_QUOTE, (_, m0, m1) => m0 + m1)
+
+            // Append escape character if string starts with html tag
+            .replace(RE_HTML_TAGS, (m0, m1) => ESCAPE_CHARACTER + m0 + m1)
     );
 }
 

--- a/src/components/markdown/RemarkRenderer.tsx
+++ b/src/components/markdown/RemarkRenderer.tsx
@@ -206,7 +206,7 @@ function sanitise(content: string) {
             .replace(RE_QUOTE, (_, m0, m1) => m0 + m1)
 
             // Append escape character if string starts with html tag
-            .replace(RE_HTML_TAGS, (m0, m1) => ESCAPE_CHARACTER + m0 + m1)
+            .replace(RE_HTML_TAGS, (match) => ESCAPE_CHARACTER + match)
     );
 }
 

--- a/src/components/markdown/plugins/removeEscapeCharacter.tsx
+++ b/src/components/markdown/plugins/removeEscapeCharacter.tsx
@@ -5,10 +5,12 @@ export const ESCAPE_CHARACTER = `${Math.random()}`;
 
 export const remarkRemoveEscapeCharacter: Plugin = () => {
     return (tree) => {
-        visit(tree, "", (node: { value: string }) => {
-            if (node.value === ESCAPE_CHARACTER) {
+        visit(tree, "", (node: { value: string; type: string }) => {
+            if (node.value === ESCAPE_CHARACTER && node.type === 'text') {
                 node.value = '';
-            }
+              } else if (node.value.includes(ESCAPE_CHARACTER) && node.type === 'code') {
+                node.value = node.value.replaceAll(ESCAPE_CHARACTER, '');
+              }
         });
     };
 };

--- a/src/components/markdown/plugins/removeEscapeCharacter.tsx
+++ b/src/components/markdown/plugins/removeEscapeCharacter.tsx
@@ -6,8 +6,8 @@ export const ESCAPE_CHARACTER = `${Math.random()}`;
 export const remarkRemoveEscapeCharacter: Plugin = () => {
     return (tree) => {
         visit(tree, "", (node: { value: string }) => {
-            if (node.value) {
-                node.value = node.value.replace(ESCAPE_CHARACTER, "");
+            if (node.value === ESCAPE_CHARACTER) {
+                node.value = '';
             }
         });
     };

--- a/src/components/markdown/plugins/removeEscapeCharacter.tsx
+++ b/src/components/markdown/plugins/removeEscapeCharacter.tsx
@@ -1,0 +1,14 @@
+import { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+export const ESCAPE_CHARACTER = `${Math.random()}`;
+
+export const remarkRemoveEscapeCharacter: Plugin = () => {
+    return (tree) => {
+        visit(tree, "", (node: { value: string }) => {
+            if (node.value) {
+                node.value = node.value.replace(ESCAPE_CHARACTER, "");
+            }
+        });
+    };
+};

--- a/src/components/markdown/plugins/removeEscapeCharacter.tsx
+++ b/src/components/markdown/plugins/removeEscapeCharacter.tsx
@@ -1,16 +1,22 @@
 import { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 
+/**
+ * Randomly generated string to escape HTML tags
+ */
 export const ESCAPE_CHARACTER = `${Math.random()}`;
 
 export const remarkRemoveEscapeCharacter: Plugin = () => {
     return (tree) => {
         visit(tree, "", (node: { value: string; type: string }) => {
-            if (node.value === ESCAPE_CHARACTER && node.type === 'text') {
-                node.value = '';
-              } else if (node.value.includes(ESCAPE_CHARACTER) && node.type === 'code') {
-                node.value = node.value.replaceAll(ESCAPE_CHARACTER, '');
-              }
+            if (node.value === ESCAPE_CHARACTER && node.type === "text") {
+                node.value = "";
+            } else if (
+                node.value.includes(ESCAPE_CHARACTER) &&
+                node.type === "code"
+            ) {
+                node.value = node.value.replaceAll(ESCAPE_CHARACTER, "");
+            }
         });
     };
 };

--- a/src/components/markdown/plugins/removeEscapeCharacter.tsx
+++ b/src/components/markdown/plugins/removeEscapeCharacter.tsx
@@ -9,11 +9,11 @@ export const ESCAPE_CHARACTER = `${Math.random()}`;
 export const remarkRemoveEscapeCharacter: Plugin = () => {
     return (tree) => {
         visit(tree, "", (node: { value: string; type: string }) => {
-            if (node.value === ESCAPE_CHARACTER && node.type === "text") {
+            if (node.type === "text" && node.value === ESCAPE_CHARACTER) {
                 node.value = "";
             } else if (
-                node.value.includes(ESCAPE_CHARACTER) &&
-                node.type === "code"
+                node.type === "code" &&
+                node.value.includes(ESCAPE_CHARACTER)
             ) {
                 node.value = node.value.replaceAll(ESCAPE_CHARACTER, "");
             }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

Fixes #733 

Before:
![image](https://user-images.githubusercontent.com/38331868/178790217-0795fe92-7b4d-4ecc-b0cc-b7475990d2ce.png)
After:
![image](https://user-images.githubusercontent.com/38331868/178798075-6a73e97b-10c3-4aad-860c-1b94f36bc665.png)

Actual markdown:
```md
### HTML Tags

#### Single-line

Nothing before:

<h1>**Markdown**

Something Before:

Text<h1>**Markdown**

#### Multi-line

<h1>**Markdown**
<h1>**Markdown**
```

---
Changes

As pointed out in https://github.com/revoltchat/revite/issues/733#issue-1303498835, if there's text before HTML tag, it would render the markdown.
going from that, the code:
- checks if a line starts with an HTML tag and adds a random escape character.
- the random escape character gets removed by [remarkRemoveEscapeCharacter](https://github.com/LedaThemis/revite/blob/2ea8ea94243af89310a6015a48120a517642df97/src/components/markdown/plugins/removeEscapeCharacter.tsx) plugin after parsing the markdown.

A thing to note is the `Math.random()`, and that should probably be replaced

---

[Issue #185 on the remark repository](https://github.com/remarkjs/remark/issues/185) is discussing the same thing