### PR TITLE
fix: render markdown inside/after HTML tags

### DIFF
--- a/src/components/markdown/RemarkRenderer.tsx
+++ b/src/components/markdown/RemarkRenderer.tsx
@@ -185,6 +185,11 @@ const Container = styled.div<{ largeEmoji: boolean }>`
 const RE_QUOTE = /(^(?:>\s){5})[>\s]+(.*$)/gm;
 
 /**
+ * Regex for matching HTML tags
+ */
+const RE_HTML_TAGS = /^(<\/?[a-zA-Z0-9]+>)(.*$)/gm;
+
+/**
  * Sanitise Markdown input before rendering
  * @param content Input string
  * @returns Sanitised string
@@ -194,6 +199,11 @@ function sanitise(content: string) {
         content
             // Strip excessive blockquote indentation
             .replace(RE_QUOTE, (_, m0, m1) => m0 + m1)
+
+            // Append empty character if string starts with html tag
+            // This is to avoid inconsistencies in rendering Markdown inside/after HTML tags
+            // https://github.com/revoltchat/revite/issues/733
+            .replace(RE_HTML_TAGS, (match) => `\u200E${match}`)
     );
 }
 


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [X] I have included screenshots to demonstrate my changes

Fixes #733 

Before:
![image](https://user-images.githubusercontent.com/38331868/178790217-0795fe92-7b4d-4ecc-b0cc-b7475990d2ce.png)
After:
![image](https://user-images.githubusercontent.com/38331868/178798075-6a73e97b-10c3-4aad-860c-1b94f36bc665.png)

Actual markdown:
```md
### HTML Tags

#### Single-line

Nothing before:

<h1>**Markdown**

Something Before:

Text<h1>**Markdown**

#### Multi-line

<h1>**Markdown**
<h1>**Markdown**
```

### Changes

As pointed out in https://github.com/revoltchat/revite/issues/733#issue-1303498835, if there's text before HTML tag, it would render the markdown. so the code adds an empty character if a line starts with an HTML tag.

This is an alternative to #734 