### PR TITLE
Swap appearance with voice settings tab on the Settings page

### DIFF
--- a/src/pages/settings/Settings.tsx
+++ b/src/pages/settings/Settings.tsx
@@ -154,14 +154,14 @@ export default observer(() => {
                     category: (
                         <Text id="app.settings.categories.client_settings" />
                     ),
-                    id: "audio",
-                    icon: <Speaker size={20} />,
-                    title: <Text id="app.settings.pages.audio.title" />,
-                },
-                {
                     id: "appearance",
                     icon: <Palette size={20} />,
                     title: <Text id="app.settings.pages.appearance.title" />,
+                },
+                {
+                    id: "audio",
+                    icon: <Speaker size={20} />,
+                    title: <Text id="app.settings.pages.audio.title" />,
                 },
                 {
                     id: "plugins",


### PR DESCRIPTION
I think that it should be on top because it may be visited more frequently than voice settings

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

![screenshot](https://user-images.githubusercontent.com/87622950/193406339-7d4ef8c0-5d56-4950-bfaa-696de6fbfdc3.png)

