### PR TITLE
fix: dash ("-" char) in emoji names

### DIFF
--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -27,7 +27,9 @@ export function App() {
                 <Masks />
                 <Switch>
                     <Route path="/login/verify/:token">
-                        <Login />
+                        <LoadSuspense>
+                            <Login />
+                        </LoadSuspense>
                     </Route>
                     <Route path="/login/reset/:token">
                         <LoadSuspense>

--- a/src/pages/login/forms/Form.tsx
+++ b/src/pages/login/forms/Form.tsx
@@ -80,7 +80,11 @@ export const Form = observer(({ page, callback }: Props) => {
         }
 
         try {
-            if (configuration?.features.captcha.enabled && page !== "reset") {
+            if (
+                configuration?.features.captcha.enabled &&
+                page !== "reset" &&
+                page !== "login"
+            ) {
                 setCaptcha({
                     onSuccess: async (captcha) => {
                         setCaptcha(undefined);


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

This fixes emoji names that have a `-` in them. For example, this fixes the usage of `:non-potable_water:` to show the emoji properly without avoiding this error by changing all emoji names to not have any `-`'s in them.

Along with fixing this bug, it also removed an unnecessary "one or more" operator in the same `RE_EMOJI` expression. This makes no difference to validating with the expression, except to readability.

before
![image](https://user-images.githubusercontent.com/26735262/200299301-1135601d-fbbf-4a71-ae29-ba76b399c2a1.png)

after
![https://res.kate.pet/upload/e11864f5-59f0-4aee-8c3b-dc9178913ac3/firefox_Tx7F6JuAHX.png](https://res.kate.pet/upload/e11864f5-59f0-4aee-8c3b-dc9178913ac3/firefox_Tx7F6JuAHX.png)