### PR TITLE
fix: allow dash char in autocorrect content validation

### DIFF
--- a/src/components/common/AutoComplete.tsx
+++ b/src/components/common/AutoComplete.tsx
@@ -64,7 +64,7 @@ export function useAutoComplete(
             const cursor = el.selectionStart;
             const content = el.value.slice(0, cursor);
 
-            const valid = /\w/;
+            const valid = /[\w\-]/;
 
             let j = content.length - 1;
             if (content[j] === "@") {


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

This fixes the `-` character when checking if something in the chat box is valid for auto-correct searching. This fixes `:non-potable_water:` when finding it via auto-correct after entering the `-` character.

Before:
![screen recording of the non-potable water emoji not working after typing the dash in](https://res.kate.pet/upload/9bd41fb2-c967-4913-9621-bccf08e26cf7/Revolt_nK6mMT4V2Q.gif)

After;
![screen recording of the dash character working when searching via autocorrect](https://res.kate.pet/upload/4edb9ea3-586b-4bb7-888d-a0bb322b6829/firefox_fcLk3CaO7N.gif)