### PR TITLE
fix(home): inconsistent discover button height

### DIFF
--- a/src/pages/home/Home.module.scss
+++ b/src/pages/home/Home.module.scss
@@ -54,3 +54,4 @@
 [data-light="true"] .home svg {
     filter: invert(100%);
 }
+

--- a/src/pages/home/Home.module.scss
+++ b/src/pages/home/Home.module.scss
@@ -34,7 +34,7 @@
 
             a {
                 width: 100%;
-
+                height: 6em;
                 div {
                     margin: 0;
                 }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

this pr fixes inconsonant height in the buttons by making all of them the same size :3
before:
![image](https://user-images.githubusercontent.com/65588168/226384735-9ae73b2d-7764-458d-974a-6e8de612cd76.png)

after:
![image](https://user-images.githubusercontent.com/65588168/226384584-1f5a4ab0-e97f-44e9-8a41-895083479eec.png)
