### PR TITLE
fix: Usernames are evolving blog post link

### DIFF
--- a/src/assets/changelogs.tsx
+++ b/src/assets/changelogs.tsx
@@ -70,7 +70,7 @@ export const changelogEntries: Record<number, ChangelogPost> = {
             {
                 type: "element",
                 element: (
-                    <a href="https://revolt.chat/post/evolving-usernames">
+                    <a href="https://revolt.chat/posts/evolving-usernames">
                         Read more on our blog!
                     </a>
                 ),


### PR DESCRIPTION
fix: Usernames are evolving link to blog page(sorry for not following proper format sorta dumb)


## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes
