### PR TITLE
Fix Link Whitelist issue

### DIFF
--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -21,31 +21,6 @@ const ALLOWED_ORIGINS = [
 ];
 
 /**
- * Permissible protocols in URLs
- */
-const PROTOCOL_WHITELIST = [
-    "http:",
-    "https:",
-    "ftp:",
-    "ftps:",
-    "mailto:",
-    "news:",
-    "irc:",
-    "gopher:",
-    "nntp:",
-    "feed:",
-    "telnet:",
-    "mms:",
-    "rtsp:",
-    "svn:",
-    "git:",
-    "tel:",
-    "fax:",
-    "xmpp:",
-    "magnet:",
-];
-
-/**
  * Determine what kind of link we are dealing with and sanitise any malicious input
  * @param href Input URL
  * @returns Link Type
@@ -65,9 +40,7 @@ export function determineLink(href?: string): LinkType {
         } catch (err) {}
 
         if (!internal && url) {
-            if (PROTOCOL_WHITELIST.includes(url.protocol)) {
-                return { type: "external", href, url };
-            }
+            return { type: "external", href, url };
         }
     }
 


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [ ] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [x] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes


filtering url protocols does not make sense as ultimately, the browser is called to decide what happens, as such i have removed that functionality. here's a few examples:

friend sends you a steam:// link for a game, but you can't open it without copypasting it to the browser manually
that's about it, unless there's some other usecase i haven't thought of