### PR TITLE
fix(settings): fixed inability to rename categories when they have blank names

### DIFF
--- a/src/pages/settings/server/Categories.tsx
+++ b/src/pages/settings/server/Categories.tsx
@@ -369,7 +369,9 @@ function ListElement({
                     <KanbanList last={false} key={category.id}>
                         <div className="inner">
                             <Row>
-                                <KanbanListHeader {...provided.dragHandleProps}>
+                                <KanbanListHeader 
+                                    {...provided.dragHandleProps}
+                                    onClick={startEditing}>
                                     {editing !== undefined ? (
                                         <input
                                             value={editing}
@@ -384,7 +386,7 @@ function ListElement({
                                             id={category.id}
                                         />
                                     ) : (
-                                        <span onClick={startEditing}>
+                                        <span>
                                             {category.title}
                                         </span>
                                     )}


### PR DESCRIPTION
This PR fixes a minor issue where using blank names in categories would lead to them being permanently\* stuck as such. 

Blank names are already prohibited, evident from the 400 error you receive if you try creating a category without entering anything in the name field. For some reason though, simple whitespace characters (including U+0020) *are* allowed. When this happens, the category gets stuck with a blank name due to the `<span>` element ending up with a size of 0x0, and since the click handler responsible for allowing the user to rename the category is attached to that same `<span>` element, you can kinda see how it goes wrong.

I realize that a change to the backend to improve handling of whitespace characters *would* be the more ideal solution, but this change on the frontend is incredibly simple, *and* it would also be nice for handling future edge cases if a similar exploit is found again.

\*unless you have access to devtools, of course.

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes
