### PR TITLE
fix: remove /download from attachments

### DIFF
--- a/src/components/common/messaging/attachments/AttachmentActions.tsx
+++ b/src/components/common/messaging/attachments/AttachmentActions.tsx
@@ -27,7 +27,7 @@ export default function AttachmentActions({ attachment }: Props) {
 
     const url = client.generateFileURL(attachment);
     const open_url = `${url}/${filename}`;
-    const download_url = url?.replace("attachments", "attachments/download");
+    const download_url = url;
 
     const filesize = determineFileSize(size);
 

--- a/src/lib/ContextMenus.tsx
+++ b/src/lib/ContextMenus.tsx
@@ -288,11 +288,7 @@ export default function ContextMenus() {
                         window.open(
                             // ! FIXME: do this from revolt.js
                             client
-                                .generateFileURL(data.attachment)
-                                ?.replace(
-                                    "attachments",
-                                    "attachments/download",
-                                ),
+                                .generateFileURL(data.attachment),
                             isFirefox || window.native ? "_blank" : "_self",
                         );
                     }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes

Due to recent changes elsewhere `/download` is no longer needed in attachment URLs. This PR removes it.
