### PR TITLE
fix: Remove caching from GitHub actions to allow compilation of docke…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,55 +30,18 @@ on:
     workflow_dispatch:
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                architecture: [linux/amd64]
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-              with:
-                  submodules: "recursive"
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
-            - name: Cache Docker layers
-              uses: actions/cache@v2
-              with:
-                  path: /tmp/.buildx-cache/${{ matrix.architecture }}
-                  key: ${{ runner.os }}-buildx-${{ matrix.architecture }}-${{ github.sha }}
-            - name: Build
-              uses: docker/build-push-action@v2
-              with:
-                  context: .
-                  platforms: ${{ matrix.architecture }}
-                  cache-from: type=local,src=/tmp/.buildx-cache/${{ matrix.architecture }}
-                  cache-to: type=local,dest=/tmp/.buildx-cache-new/${{ matrix.architecture }},mode=max
-            - name: Move cache
-              run: |
-                  rm -rf /tmp/.buildx-cache/${{ matrix.architecture }}
-                  mv /tmp/.buildx-cache-new/${{ matrix.architecture }} /tmp/.buildx-cache/${{ matrix.architecture }}
-
     publish:
-        needs: [test]
         runs-on: ubuntu-latest
         if: github.event_name != 'pull_request'
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   submodules: "recursive"
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v1
+              uses: docker/setup-qemu-action@v3
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v1
-            - name: Cache amd64 Docker layers
-              uses: actions/cache@v2
-              with:
-                  path: /tmp/.buildx-cache/linux/amd64
-                  key: ${{ runner.os }}-buildx-linux/amd64-${{ github.sha }}
+              uses: docker/setup-buildx-action@v3
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v3
@@ -86,26 +49,22 @@ jobs:
                   images: revoltchat/client, ghcr.io/revoltchat/client
             - name: Login to DockerHub
               uses: docker/login-action@v1
+              if: github.event_name != 'pull_request'
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
             - name: Login to Github Container Registry
-              uses: docker/login-action@v1
+              uses: docker/login-action@v3
+              if: github.event_name != 'pull_request'
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build and publish
-              uses: docker/build-push-action@v2
+              uses: docker/build-push-action@v6
               with:
                   context: .
-                  push: true
+                  push: ${{ github.event_name != 'pull_request' }}
                   platforms: linux/amd64
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=local,src=/tmp/.buildx-cache/linux/amd64
-                  cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-            - name: Move cache
-              run: |
-                  rm -rf /tmp/.buildx-cache
-                  mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
…r container

The GitHub action `actions/cache@v2` is no longer available. Last successful docker build was 2024-11-15

I've removed the caching, as merely upgrading the version of the cache script did not fix the problem. Since the revoltchat/revite is deprecated I believe that the lack of caching in builds shouldn't be an undue burden on GitHub. Only 9 commits have been made here since builds stopped working

The logic for publishing Docker containers has been shuffled so that the build is executed only once when publishing.

I have tested building to GitHub's container registry, but not to dockerhub, I do not forsee any issues there.

Main reason for doing this, is that a fix for attachment downloads (https://github.com/revoltchat/revite/pull/1067) is not easily available to anyone running self-hosted.

## Please make sure to check the following tasks before opening and submitting a PR

* [ ] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [ ] I have included screenshots to demonstrate my changes
