### PR TITLE
chore: tidy up CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Please make sure to check the following tasks before opening and submitting a PR
 
-* [ ] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
+* [ ] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
 * [ ] I have tested my changes locally and they are working as intended
 * [ ] These changes do not have any notable side effects on other Revolt projects
 * [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)


### PR DESCRIPTION
Hi, in testing for another PR involving the CI I got an error when I tried to create a PR, there is a workflow that tried to run, and so I'm setting it so that it only runs on a repo owned by revoltchat.

I'm likely to file the same PR against revoltchat/frontend as time permits.

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
~~* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)~~
~~* [ ] I have included screenshots to demonstrate my changes~~
