### PR TITLE
Use localStorage for emoji pack setting

### DIFF
--- a/src/components/common/Emoji.tsx
+++ b/src/components/common/Emoji.tsx
@@ -1,12 +1,13 @@
 import { emojiDictionary } from "../../assets/emojis";
 
 export type EmojiPack = "mutant" | "twemoji" | "noto" | "openmoji";
-
-let EMOJI_PACK: EmojiPack = "mutant";
+const storedPack = localStorage.getItem("emojiPack")
+let EMOJI_PACK: EmojiPack = storedPack === "mutant" || storedPack === "twemoji" || storedPack === "noto" || storedPack === "openmoji" ? storedPack : "mutant"
 const REVISION = 3;
 
 export function setGlobalEmojiPack(pack: EmojiPack) {
     EMOJI_PACK = pack;
+    localStorage.setItem("emojiPack", pack)
 }
 
 // Originally taken from Twemoji source code,


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [✅] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
* [✅] I have tested my changes locally and they are working as intended
* [✅] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [✅] I have included screenshots to demonstrate my changes

The emoji pack selector returned to default every time the page was reloaded. Added localStorage to the function that changes the pack globally to also save the change.

Fixes part of #1117 

![image](https://github.com/user-attachments/assets/2feb7f82-95d7-4c36-83c1-0fbe9617f7f5)
