### PR TITLE
fix: Make animated WebP emotes properly animate

### DIFF
--- a/src/components/markdown/plugins/emoji.tsx
+++ b/src/components/markdown/plugins/emoji.tsx
@@ -34,7 +34,7 @@ export function RenderEmoji({ match }: CustomComponentProps) {
         ? `${
               clientController.getAvailableClient().configuration?.features
                   .autumn.url
-          }/emojis/${match}`
+          }/emojis/${match}/original`
         : parseEmoji(
               match in emojiDictionary
                   ? emojiDictionary[match as keyof typeof emojiDictionary]


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes

Changes to Autumn several months ago created an issue where Revite will pull image previews for emotes instead of the emote image itself. This is fine for static emotes, but it causes issues specifically with animated WebP emotes (and perhaps static WebP emotes as well, though I haven't tested).

This PR fixes that by changing the URL used to fetch emotes, suffixing it with `/original`. This bypasses the image preview entirely and fetches the real emote image data.

An example of a broken emote with the current code (ID `01HY26VF5KMGAVMK14HPRDPWDT`):
<img width="259" height="67" alt="image" src="https://github.com/user-attachments/assets/7c9f73ce-cb05-455e-9ca7-269bf4db865b" />

The same emote, now animating properly:
<img width="267" height="76" alt="image" src="https://github.com/user-attachments/assets/d152ec34-459c-4f45-8272-ba39b0d2195e" />