### PR TITLE
fix: filter out members without ViewChannel

### DIFF
--- a/src/components/navigation/right/MemberSidebar.tsx
+++ b/src/components/navigation/right/MemberSidebar.tsx
@@ -76,17 +76,25 @@ function useEntries(
 
         keys.forEach((key) => {
             let u;
+            let member;
+
             if (isServer) {
                 const { server, user } = JSON.parse(key);
                 if (server !== channel.server_id) return;
+
                 u = client.users.get(user);
+                member = client.members.get(key);
+
+                if (!member?.hasPermission(channel, "ViewChannel")) {
+                    return;
+                }
             } else {
                 u = client.users.get(key);
+                member = client.members.get(key);
             }
 
             if (!u) return;
 
-            const member = client.members.get(key);
             const sort = member?.nickname ?? u.username;
             const entry = [u, sort] as [User, string];
 


### PR DESCRIPTION
Small fix to add a ViewChannel check when rendering members in the sidebar, just so people on Revite can have a better experience while waiting for Revolt for Web

## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects