### PR TITLE
fix: correct open/download link behaviour

### DIFF
--- a/src/components/common/messaging/attachments/AttachmentActions.tsx
+++ b/src/components/common/messaging/attachments/AttachmentActions.tsx
@@ -26,8 +26,8 @@ export default function AttachmentActions({ attachment }: Props) {
     const { filename, metadata, size } = attachment;
 
     const url = client.generateFileURL(attachment);
-    const open_url = `${url}/${filename}`;
-    const download_url = url;
+    const open_url = url;
+    const download_url = `${url}/${filename}`;
 
     const filesize = determineFileSize(size);
 


### PR DESCRIPTION
The open button now opens file in browser and download button downloads the file, so things are back in place and not swapped.

## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
* [X] I have included screenshots to demonstrate my changes
<img width="85" height="41" alt="image" src="https://github.com/user-attachments/assets/8774d24c-7c8a-4ce2-be3f-a18187a998a8" />
←  These do the thing properly now