### PR TITLE
Only members with the ability to see a channel should show up in that channels server member list.

### DIFF
--- a/src/components/navigation/right/MemberSidebar.tsx
+++ b/src/components/navigation/right/MemberSidebar.tsx
@@ -98,30 +98,33 @@ function useEntries(
             const sort = member?.nickname ?? u.username;
             const entry = [u, sort] as [User, string];
 
-            if (!u.online || u.status?.presence === "Invisible") {
-                categories.offline.push(entry);
-            } else {
-                if (isServer) {
-                    // Sort users into hoisted roles here.
-                    if (member?.roles && roles) {
-                        let success = false;
-                        for (const role of roleList) {
-                            if (member.roles.includes(role)) {
-                                categories[role].push(entry);
-                                success = true;
-                                break;
-                            }
-                        }
-
-                        if (success) return;
-                    }
+            if (member?.hasPermission(channel, "ViewChannel") || channel.recipient_ids?.includes(u._id)) {
+                if (!u.online || u.status?.presence === "Invisible") {
+                    categories.offline.push(entry);
                 } else {
-                    // Sort users into "participants" list here.
-                    // For voice calls.
+                    if (isServer) {
+                        // Sort users into hoisted roles here.
+                        if (member?.roles && roles) {
+                            let success = false;
+                            for (const role of roleList) {
+                                if (member.roles.includes(role)) {
+                                    categories[role].push(entry);
+                                    success = true;
+                                    break;
+                                }
+                            }
+    
+                            if (success) return;
+                        }
+                    } else {
+                        // Sort users into "participants" list here.
+                        // For voice calls.
+                    }
+    
+                    categories.online.push(entry);
                 }
-
-                categories.online.push(entry);
             }
+               
         });
 
         Object.keys(categories).forEach((key) =>


### PR DESCRIPTION
This change makes it so that if a member is within the group chat or has the ViewChannel permission only then do they appear in the server members sidebar. Only members with access to said channel should be visible. 

On a channel where corruption has ViewChannel access;
<img width="232" height="219" alt="image" src="https://github.com/user-attachments/assets/bd7f25a8-5a3a-4c9e-8d80-24533aff3995" />

On a channel where corruption has had ViewChannel access denied;
<img width="225" height="267" alt="image" src="https://github.com/user-attachments/assets/ff2390c0-2f1e-43ba-afbb-7101858f32a2" />

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://developers.revolt.chat/contrib.html)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
* [ ] (optional) I have opened a pull request on [the translation repository](https://github.com/revoltchat/translations)
* [x] I have included screenshots to demonstrate my changes


